### PR TITLE
Add configurable duration threshold for notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,56 @@
+# Changelog
+
+All notable changes to Claude Notifier will be documented in this file.
+
+## [2.2.0] - 2026-03-01
+
+### Added
+- Configurable duration threshold (`claudeNotifier.durationThreshold`) — suppress all notification sounds until Claude has been working for at least N seconds
+- Status bar tooltip shows threshold value when configured
+- PreToolUse hook now fires for all tools to reliably track task start time
+
+### Changed
+- Threshold applies to all notification types (completion, permission, question), not just task completion
+
+### Fixed
+- Text-only responses no longer trigger false completion sounds when threshold is enabled
+- Auto-approved tools (no permission prompt) now correctly record task start time
+
+## [2.1.0] - 2026-02-28
+
+### Added
+- Homebrew install support (`brew tap ashmitb95/claude-notifier && brew install claude-notifier`)
+
+## [2.0.1] - 2026-02-27
+
+### Fixed
+- Marketplace republish with correct publisher ID
+
+## [2.0.0] - 2026-02-27
+
+### Added
+- Per-event notification levels: `sound+popup`, `sound`, `popup`, `off`
+- Per-event sound presets (14 macOS sounds, 8 Windows sounds)
+- Three separate hooks: Stop, PermissionRequest, PreToolUse (AskUserQuestion)
+- Configuration synced to `~/.claude/hooks/claude-notifier-config.json`
+
+### Changed
+- Replaced single notification hook with three event-specific hooks
+- Sound and popup can now be controlled independently per event type
+
+## [1.0.0] - 2026-02-26
+
+### Added
+- Three distinct hooks for permission, question, and task completion events
+- CLI install/uninstall scripts for terminal-only usage
+- Windows and WSL support via PowerShell hooks
+- Global mute toggle in status bar
+- Auto-setup on extension activation, teardown on uninstall
+
+## [0.1.0] - 2026-02-25
+
+### Added
+- Initial release
+- Plays a sound when Claude Code finishes a task
+- macOS support with `afplay`
+- VSCode status bar toggle

--- a/README.md
+++ b/README.md
@@ -74,7 +74,10 @@ Open **Settings** → search **"Claude Notifier"** (`Cmd+,` / `Ctrl+,`), or add 
   // Per-event sound preset (see list below)
   "claudeNotifier.taskCompleted.sound": "Hero",
   "claudeNotifier.needsPermission.sound": "Glass",
-  "claudeNotifier.asksQuestion.sound": "Funk"
+  "claudeNotifier.asksQuestion.sound": "Funk",
+
+  // Only notify when Claude works longer than this many seconds (0 = always)
+  "claudeNotifier.durationThreshold": 0
 }
 ```
 
@@ -86,6 +89,10 @@ Open **Settings** → search **"Claude Notifier"** (`Cmd+,` / `Ctrl+,`), or add 
 | `sound`       | Yes   | No              | No           |
 | `popup`       | No    | Yes             | Yes          |
 | `off`         | No    | No              | No           |
+
+**Duration threshold:**
+
+Set `claudeNotifier.durationThreshold` to a number of seconds. The "task completed" sound will only play if Claude worked for at least that long. This is useful if you don't want to be pinged for quick responses. Set to `0` (default) to always notify. Permission and question notifications are not affected — they always fire immediately since they require your input.
 
 **Sound presets:**
 - macOS: Basso, Blow, Bottle, Frog, Funk, Glass, Hero, Morse, Ping, Pop, Purr, Sosumi, Submarine, Tink

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Open **Settings** → search **"Claude Notifier"** (`Cmd+,` / `Ctrl+,`), or add 
 
 **Duration threshold:**
 
-Set `claudeNotifier.durationThreshold` to a number of seconds. The "task completed" sound will only play if Claude worked for at least that long. This is useful if you don't want to be pinged for quick responses. Set to `0` (default) to always notify. Permission and question notifications are not affected — they always fire immediately since they require your input.
+Set `claudeNotifier.durationThreshold` to a number of seconds. All notification sounds (task completed, permission, and question) will only play if Claude has been working for at least that long. This is useful when you're actively watching the IDE and don't need audio alerts for quick interactions. Set to `0` (default) to always notify.
 
 **Sound presets:**
 - macOS: Basso, Blow, Bottle, Frog, Funk, Glass, Hero, Morse, Ping, Pop, Purr, Sosumi, Submarine, Tink

--- a/hook/claude-notifier-on-notification.js
+++ b/hook/claude-notifier-on-notification.js
@@ -5,12 +5,27 @@ const fs = require("fs");
 const path = require("path");
 const { execSync } = require("child_process");
 
-const HOOKS_DIR = path.join(process.env.HOME || process.env.USERPROFILE || "~", ".claude", "hooks");
+const HOOKS_DIR = path.join(
+  process.env.HOME || process.env.USERPROFILE || "~",
+  ".claude",
+  "hooks",
+);
 const MUTE_FLAG = path.join(HOOKS_DIR, "claude-notifier-muted");
+
 const IS_WIN = process.platform === "win32";
-const IS_WSL = !IS_WIN && process.platform === "linux" && (() => {
-  try { return fs.readFileSync("/proc/version", "utf-8").toLowerCase().includes("microsoft"); } catch { return false; }
-})();
+const IS_WSL =
+  !IS_WIN &&
+  process.platform === "linux" &&
+  (() => {
+    try {
+      return fs
+        .readFileSync("/proc/version", "utf-8")
+        .toLowerCase()
+        .includes("microsoft");
+    } catch {
+      return false;
+    }
+  })();
 const USE_WIN = IS_WIN || IS_WSL;
 const PS_BIN = IS_WSL ? "powershell.exe" : "powershell";
 
@@ -23,7 +38,11 @@ process.stdin.setEncoding("utf-8");
 process.stdin.on("data", (chunk) => (raw += chunk));
 process.stdin.on("end", () => {
   let input = {};
-  try { input = JSON.parse(raw); } catch { process.exit(0); }
+  try {
+    input = JSON.parse(raw);
+  } catch {
+    process.exit(0);
+  }
 
   if (input.notification_type !== "permission_prompt") process.exit(0);
   if (fs.existsSync(MUTE_FLAG)) process.exit(0);
@@ -32,7 +51,10 @@ process.stdin.on("end", () => {
   try {
     if (USE_WIN) {
       const ps = `$s='${SOUND}'; if(Test-Path $s){(New-Object Media.SoundPlayer $s).PlaySync()}else{[console]::Beep(800,300)}`;
-      execSync(`${PS_BIN} -NoProfile -NonInteractive -EncodedCommand ${Buffer.from(ps, "utf16le").toString("base64")}`, { stdio: "ignore", timeout: 5000 });
+      execSync(
+        `${PS_BIN} -NoProfile -NonInteractive -EncodedCommand ${Buffer.from(ps, "utf16le").toString("base64")}`,
+        { stdio: "ignore", timeout: 5000 },
+      );
     } else {
       execSync(`afplay "${SOUND}"`, { stdio: "ignore" });
     }
@@ -44,15 +66,24 @@ process.stdin.on("end", () => {
     if (USE_WIN) {
       const safeMsg = message.replace(/'/g, "''");
       const ps = `Add-Type -AssemblyName System.Windows.Forms; $n=New-Object System.Windows.Forms.NotifyIcon; $n.Icon=[System.Drawing.SystemIcons]::Information; $n.Visible=$true; $n.ShowBalloonTip(3000,'Claude Notifier','${safeMsg}',[System.Windows.Forms.ToolTipIcon]::None); Start-Sleep -m 500; $n.Dispose()`;
-      execSync(`${PS_BIN} -NoProfile -NonInteractive -EncodedCommand ${Buffer.from(ps, "utf16le").toString("base64")}`, { stdio: "ignore", timeout: 5000 });
+      execSync(
+        `${PS_BIN} -NoProfile -NonInteractive -EncodedCommand ${Buffer.from(ps, "utf16le").toString("base64")}`,
+        { stdio: "ignore", timeout: 5000 },
+      );
     } else {
-      execSync(`osascript -e 'display notification "${message}" with title "Claude Notifier"'`, { stdio: "ignore" });
+      execSync(
+        `osascript -e 'display notification "${message}" with title "Claude Notifier"'`,
+        { stdio: "ignore" },
+      );
     }
   } catch {}
 
   // Write signal for VSCode extension
   try {
-    fs.writeFileSync(path.join(HOOKS_DIR, "claude-signal"), "input " + Date.now());
+    fs.writeFileSync(
+      path.join(HOOKS_DIR, "claude-signal"),
+      "input " + Date.now(),
+    );
   } catch {}
 
   process.exit(0);

--- a/hook/claude-notifier-on-permission.js
+++ b/hook/claude-notifier-on-permission.js
@@ -65,6 +65,15 @@ process.stdin.on("end", () => {
 
   if (level === "off") process.exit(0);
 
+  // Duration threshold check — skip sound if task is still short (user is watching)
+  const threshold = config?.durationThreshold ?? 0;
+  if (threshold > 0) {
+    let startTime = 0;
+    try { startTime = parseInt(fs.readFileSync(TASKSTART_FILE, "utf-8").trim(), 10); } catch {}
+    const elapsed = (Date.now() - startTime) / 1000;
+    if (elapsed < threshold) process.exit(0);
+  }
+
   const sound = resolveSound(eventCfg.sound, "/System/Library/Sounds/Glass.aiff", "C:\\Windows\\Media\\Windows Notify.wav");
 
   // Play sound

--- a/hook/claude-notifier-on-permission.js
+++ b/hook/claude-notifier-on-permission.js
@@ -7,6 +7,8 @@ const { execSync } = require("child_process");
 
 const HOOKS_DIR = path.join(process.env.HOME || process.env.USERPROFILE || "~", ".claude", "hooks");
 const MUTE_FLAG = path.join(HOOKS_DIR, "claude-notifier-muted");
+const TASKSTART_FILE = path.join(HOOKS_DIR, "claude-notifier-taskstart");
+
 const IS_WIN = process.platform === "win32";
 const IS_WSL = !IS_WIN && process.platform === "linux" && (() => {
   try { return fs.readFileSync("/proc/version", "utf-8").toLowerCase().includes("microsoft"); } catch { return false; }
@@ -48,6 +50,11 @@ process.stdin.on("end", () => {
   try { input = JSON.parse(raw); } catch { process.exit(0); }
 
   if (fs.existsSync(MUTE_FLAG)) process.exit(0);
+
+  // Write task-start marker for duration threshold (only if not already set)
+  if (!fs.existsSync(TASKSTART_FILE)) {
+    try { fs.writeFileSync(TASKSTART_FILE, String(Date.now())); } catch {}
+  }
 
   // Skip AskUserQuestion — handled by the PreToolUse question hook
   if (input.tool_name === "AskUserQuestion") process.exit(0);

--- a/hook/claude-notifier-on-permission.ps1
+++ b/hook/claude-notifier-on-permission.ps1
@@ -37,6 +37,18 @@ $level = if ($eventCfg -and $eventCfg.level) { $eventCfg.level } else { 'sound+p
 
 if ($level -eq 'off') { exit 0 }
 
+# Duration threshold check — skip sound if task is still short (user is watching)
+$threshold = if ($config -and $config.durationThreshold) { $config.durationThreshold } else { 0 }
+if ($threshold -gt 0) {
+    $startTime = 0
+    if (Test-Path $taskStartFile) {
+        try { $startTime = [long](Get-Content $taskStartFile -Raw).Trim() } catch {}
+    }
+    $nowMs = [long]([DateTimeOffset]::UtcNow.ToUnixTimeMilliseconds())
+    $elapsed = ($nowMs - $startTime) / 1000
+    if ($elapsed -lt $threshold) { exit 0 }
+}
+
 $soundName = if ($eventCfg -and $eventCfg.sound) { $eventCfg.sound } else { '' }
 $soundPath = if ($winSounds.ContainsKey($soundName)) { $winSounds[$soundName] } else { 'C:\Windows\Media\Windows Notify.wav' }
 

--- a/hook/claude-notifier-on-permission.ps1
+++ b/hook/claude-notifier-on-permission.ps1
@@ -5,6 +5,7 @@ $ErrorActionPreference = 'SilentlyContinue'
 $hooksDir = Join-Path ($env:USERPROFILE) '.claude' 'hooks'
 $muteFlag = Join-Path $hooksDir 'claude-notifier-muted'
 $configFile = Join-Path $hooksDir 'claude-notifier-config.json'
+$taskStartFile = Join-Path $hooksDir 'claude-notifier-taskstart'
 
 $winSounds = @{
     'Windows Notify' = 'C:\Windows\Media\Windows Notify.wav'
@@ -21,6 +22,11 @@ $raw = [Console]::In.ReadToEnd()
 try { $data = $raw | ConvertFrom-Json } catch { exit 0 }
 
 if (Test-Path $muteFlag) { exit 0 }
+
+# Write task-start marker for duration threshold (only if not already set)
+if (-not (Test-Path $taskStartFile)) {
+    try { Set-Content -Path $taskStartFile -Value ([DateTimeOffset]::UtcNow.ToUnixTimeMilliseconds()) -NoNewline } catch {}
+}
 
 # Read config
 $config = $null

--- a/hook/claude-notifier-on-question.js
+++ b/hook/claude-notifier-on-question.js
@@ -7,6 +7,8 @@ const { execSync } = require("child_process");
 
 const HOOKS_DIR = path.join(process.env.HOME || process.env.USERPROFILE || "~", ".claude", "hooks");
 const MUTE_FLAG = path.join(HOOKS_DIR, "claude-notifier-muted");
+const TASKSTART_FILE = path.join(HOOKS_DIR, "claude-notifier-taskstart");
+
 const IS_WIN = process.platform === "win32";
 const IS_WSL = !IS_WIN && process.platform === "linux" && (() => {
   try { return fs.readFileSync("/proc/version", "utf-8").toLowerCase().includes("microsoft"); } catch { return false; }
@@ -48,6 +50,11 @@ process.stdin.on("end", () => {
   try { input = JSON.parse(raw); } catch { process.exit(0); }
 
   if (fs.existsSync(MUTE_FLAG)) process.exit(0);
+
+  // Write task-start marker for duration threshold (only if not already set)
+  if (!fs.existsSync(TASKSTART_FILE)) {
+    try { fs.writeFileSync(TASKSTART_FILE, String(Date.now())); } catch {}
+  }
 
   const config = readConfig();
   const eventCfg = config?.asksQuestion ?? {};

--- a/hook/claude-notifier-on-question.js
+++ b/hook/claude-notifier-on-question.js
@@ -56,11 +56,23 @@ process.stdin.on("end", () => {
     try { fs.writeFileSync(TASKSTART_FILE, String(Date.now())); } catch {}
   }
 
+  // Only play question sound for AskUserQuestion; other tools just need the marker above
+  if (input.tool_name !== "AskUserQuestion") process.exit(0);
+
   const config = readConfig();
   const eventCfg = config?.asksQuestion ?? {};
   const level = eventCfg.level ?? "sound+popup";
 
   if (level === "off") process.exit(0);
+
+  // Duration threshold check — skip sound if task is still short (user is watching)
+  const threshold = config?.durationThreshold ?? 0;
+  if (threshold > 0) {
+    let startTime = 0;
+    try { startTime = parseInt(fs.readFileSync(TASKSTART_FILE, "utf-8").trim(), 10); } catch {}
+    const elapsed = (Date.now() - startTime) / 1000;
+    if (elapsed < threshold) process.exit(0);
+  }
 
   const sound = resolveSound(eventCfg.sound, "/System/Library/Sounds/Funk.aiff", "C:\\Windows\\Media\\Windows Notify.wav");
 

--- a/hook/claude-notifier-on-question.ps1
+++ b/hook/claude-notifier-on-question.ps1
@@ -28,6 +28,9 @@ if (-not (Test-Path $taskStartFile)) {
     try { Set-Content -Path $taskStartFile -Value ([DateTimeOffset]::UtcNow.ToUnixTimeMilliseconds()) -NoNewline } catch {}
 }
 
+# Only play question sound for AskUserQuestion; other tools just need the marker above
+if ($data.tool_name -ne 'AskUserQuestion') { exit 0 }
+
 # Read config
 $config = $null
 try { $config = (Get-Content $configFile -Raw) | ConvertFrom-Json } catch {}
@@ -36,6 +39,18 @@ $eventCfg = if ($config -and $config.asksQuestion) { $config.asksQuestion } else
 $level = if ($eventCfg -and $eventCfg.level) { $eventCfg.level } else { 'sound+popup' }
 
 if ($level -eq 'off') { exit 0 }
+
+# Duration threshold check — skip sound if task is still short (user is watching)
+$threshold = if ($config -and $config.durationThreshold) { $config.durationThreshold } else { 0 }
+if ($threshold -gt 0) {
+    $startTime = 0
+    if (Test-Path $taskStartFile) {
+        try { $startTime = [long](Get-Content $taskStartFile -Raw).Trim() } catch {}
+    }
+    $nowMs = [long]([DateTimeOffset]::UtcNow.ToUnixTimeMilliseconds())
+    $elapsed = ($nowMs - $startTime) / 1000
+    if ($elapsed -lt $threshold) { exit 0 }
+}
 
 $soundName = if ($eventCfg -and $eventCfg.sound) { $eventCfg.sound } else { '' }
 $soundPath = if ($winSounds.ContainsKey($soundName)) { $winSounds[$soundName] } else { 'C:\Windows\Media\Windows Notify.wav' }

--- a/hook/claude-notifier-on-question.ps1
+++ b/hook/claude-notifier-on-question.ps1
@@ -5,6 +5,7 @@ $ErrorActionPreference = 'SilentlyContinue'
 $hooksDir = Join-Path ($env:USERPROFILE) '.claude' 'hooks'
 $muteFlag = Join-Path $hooksDir 'claude-notifier-muted'
 $configFile = Join-Path $hooksDir 'claude-notifier-config.json'
+$taskStartFile = Join-Path $hooksDir 'claude-notifier-taskstart'
 
 $winSounds = @{
     'Windows Notify' = 'C:\Windows\Media\Windows Notify.wav'
@@ -21,6 +22,11 @@ $raw = [Console]::In.ReadToEnd()
 try { $data = $raw | ConvertFrom-Json } catch { exit 0 }
 
 if (Test-Path $muteFlag) { exit 0 }
+
+# Write task-start marker for duration threshold (only if not already set)
+if (-not (Test-Path $taskStartFile)) {
+    try { Set-Content -Path $taskStartFile -Value ([DateTimeOffset]::UtcNow.ToUnixTimeMilliseconds()) -NoNewline } catch {}
+}
 
 # Read config
 $config = $null

--- a/hook/claude-notifier-on-stop.js
+++ b/hook/claude-notifier-on-stop.js
@@ -96,16 +96,15 @@ process.stdin.on("end", () => {
     process.exit(0);
   }
 
-  // Duration threshold check — only skip for "done" events, not "question"
+  // Duration threshold check — suppress all sounds if task is shorter than threshold
   const threshold = config?.durationThreshold ?? 0;
-  if (reason === "done" && threshold > 0) {
+  if (threshold > 0) {
     let startTime = 0;
     try { startTime = parseInt(fs.readFileSync(TASKSTART_FILE, "utf-8").trim(), 10); } catch {}
     try { fs.unlinkSync(TASKSTART_FILE); } catch {}
-    if (startTime > 0) {
-      const elapsed = (Date.now() - startTime) / 1000;
-      if (elapsed < threshold) process.exit(0);
-    }
+    if (startTime <= 0) process.exit(0); // no marker = quick response, user is still watching
+    const elapsed = (Date.now() - startTime) / 1000;
+    if (elapsed < threshold) process.exit(0);
   } else {
     try { fs.unlinkSync(TASKSTART_FILE); } catch {}
   }

--- a/hook/claude-notifier-on-stop.js
+++ b/hook/claude-notifier-on-stop.js
@@ -7,6 +7,8 @@ const { execSync } = require("child_process");
 
 const HOOKS_DIR = path.join(process.env.HOME || process.env.USERPROFILE || "~", ".claude", "hooks");
 const MUTE_FLAG = path.join(HOOKS_DIR, "claude-notifier-muted");
+const TASKSTART_FILE = path.join(HOOKS_DIR, "claude-notifier-taskstart");
+
 const IS_WIN = process.platform === "win32";
 const IS_WSL = !IS_WIN && process.platform === "linux" && (() => {
   try { return fs.readFileSync("/proc/version", "utf-8").toLowerCase().includes("microsoft"); } catch { return false; }
@@ -89,7 +91,24 @@ process.stdin.on("end", () => {
   const eventCfg = config?.[configKey] ?? {};
   const level = eventCfg.level ?? "sound+popup";
 
-  if (level === "off") process.exit(0);
+  if (level === "off") {
+    try { fs.unlinkSync(TASKSTART_FILE); } catch {}
+    process.exit(0);
+  }
+
+  // Duration threshold check — only skip for "done" events, not "question"
+  const threshold = config?.durationThreshold ?? 0;
+  if (reason === "done" && threshold > 0) {
+    let startTime = 0;
+    try { startTime = parseInt(fs.readFileSync(TASKSTART_FILE, "utf-8").trim(), 10); } catch {}
+    try { fs.unlinkSync(TASKSTART_FILE); } catch {}
+    if (startTime > 0) {
+      const elapsed = (Date.now() - startTime) / 1000;
+      if (elapsed < threshold) process.exit(0);
+    }
+  } else {
+    try { fs.unlinkSync(TASKSTART_FILE); } catch {}
+  }
 
   const sound = resolveSound(eventCfg.sound, DEFAULT_SOUNDS[reason].mac, DEFAULT_SOUNDS[reason].win);
 

--- a/hook/claude-notifier-on-stop.ps1
+++ b/hook/claude-notifier-on-stop.ps1
@@ -60,19 +60,18 @@ if ($level -eq 'off') {
     exit 0
 }
 
-# Duration threshold check — only skip for "done" events, not "question"
+# Duration threshold check — suppress all sounds if task is shorter than threshold
 $threshold = if ($config -and $config.durationThreshold) { $config.durationThreshold } else { 0 }
-if ($reason -eq 'done' -and $threshold -gt 0) {
+if ($threshold -gt 0) {
     $startTime = 0
     if (Test-Path $taskStartFile) {
         try { $startTime = [long](Get-Content $taskStartFile -Raw).Trim() } catch {}
     }
     Remove-Item -Path $taskStartFile -Force -ErrorAction SilentlyContinue
-    if ($startTime -gt 0) {
-        $nowMs = [long]([DateTimeOffset]::UtcNow.ToUnixTimeMilliseconds())
-        $elapsed = ($nowMs - $startTime) / 1000
-        if ($elapsed -lt $threshold) { exit 0 }
-    }
+    if ($startTime -le 0) { exit 0 } # no marker = quick response, user is still watching
+    $nowMs = [long]([DateTimeOffset]::UtcNow.ToUnixTimeMilliseconds())
+    $elapsed = ($nowMs - $startTime) / 1000
+    if ($elapsed -lt $threshold) { exit 0 }
 } else {
     Remove-Item -Path $taskStartFile -Force -ErrorAction SilentlyContinue
 }

--- a/hook/claude-notifier-on-stop.ps1
+++ b/hook/claude-notifier-on-stop.ps1
@@ -5,6 +5,7 @@ $ErrorActionPreference = 'SilentlyContinue'
 $hooksDir = Join-Path ($env:USERPROFILE) '.claude' 'hooks'
 $muteFlag = Join-Path $hooksDir 'claude-notifier-muted'
 $configFile = Join-Path $hooksDir 'claude-notifier-config.json'
+$taskStartFile = Join-Path $hooksDir 'claude-notifier-taskstart'
 
 $winSounds = @{
     'Windows Notify' = 'C:\Windows\Media\Windows Notify.wav'
@@ -54,7 +55,27 @@ $configKey = if ($reason -eq 'question') { 'asksQuestion' } else { 'taskComplete
 $eventCfg = if ($config -and $config.$configKey) { $config.$configKey } else { $null }
 $level = if ($eventCfg -and $eventCfg.level) { $eventCfg.level } else { 'sound+popup' }
 
-if ($level -eq 'off') { exit 0 }
+if ($level -eq 'off') {
+    Remove-Item -Path $taskStartFile -Force -ErrorAction SilentlyContinue
+    exit 0
+}
+
+# Duration threshold check — only skip for "done" events, not "question"
+$threshold = if ($config -and $config.durationThreshold) { $config.durationThreshold } else { 0 }
+if ($reason -eq 'done' -and $threshold -gt 0) {
+    $startTime = 0
+    if (Test-Path $taskStartFile) {
+        try { $startTime = [long](Get-Content $taskStartFile -Raw).Trim() } catch {}
+    }
+    Remove-Item -Path $taskStartFile -Force -ErrorAction SilentlyContinue
+    if ($startTime -gt 0) {
+        $nowMs = [long]([DateTimeOffset]::UtcNow.ToUnixTimeMilliseconds())
+        $elapsed = ($nowMs - $startTime) / 1000
+        if ($elapsed -lt $threshold) { exit 0 }
+    }
+} else {
+    Remove-Item -Path $taskStartFile -Force -ErrorAction SilentlyContinue
+}
 
 $defaultSounds = @{ question = 'C:\Windows\Media\Windows Notify.wav'; done = 'C:\Windows\Media\tada.wav' }
 $soundName = if ($eventCfg -and $eventCfg.sound) { $eventCfg.sound } else { '' }

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
           "type": "number",
           "default": 0,
           "minimum": 0,
-          "description": "Minimum task duration (seconds) before playing the completion sound. Set to 0 to always notify. For example, set to 10 to only get notified when Claude works for 10+ seconds."
+          "description": "Minimum task duration (seconds) before playing any notification sound. Set to 0 to always notify. For example, set to 10 to only get notified when Claude works for 10+ seconds."
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "claude-notifier",
   "displayName": "Claude Notifier",
   "description": "Plays distinct sounds when Claude Code finishes a task or needs your input",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "icon": "media/icon.png",
   "publisher": "SingularityInc",
   "repository": {
@@ -78,6 +78,12 @@
           "enum": ["Basso", "Blow", "Bottle", "Frog", "Funk", "Glass", "Hero", "Morse", "Ping", "Pop", "Purr", "Sosumi", "Submarine", "Tink", "Windows Notify", "tada", "chimes", "chord", "ding", "notify", "ringin", "Windows Background"],
           "default": "Funk",
           "description": "Sound preset when Claude asks a question. macOS: Basso–Tink. Windows: Windows Notify–Windows Background."
+        },
+        "claudeNotifier.durationThreshold": {
+          "type": "number",
+          "default": 0,
+          "minimum": 0,
+          "description": "Minimum task duration (seconds) before playing the completion sound. Set to 0 to always notify. For example, set to 10 to only get notified when Claude works for 10+ seconds."
         }
       }
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -175,12 +175,19 @@ function setupHooks(context: vscode.ExtensionContext) {
       entry.hooks?.some((h: any) => h.command?.includes(needle) && h.command?.startsWith(expectedPrefix))
     );
 
+  // PreToolUse must fire for ALL tools (no matcher) to track task start time.
+  // If it has a matcher (legacy), force re-registration.
+  const preToolUseNeedsFix = settings.hooks?.PreToolUse?.some((entry: any) =>
+    entry.matcher && entry.hooks?.some((h: any) => h.command?.includes("claude-notifier-on-question"))
+  );
+
   if (
+    !preToolUseNeedsFix &&
     hasHook("Stop", "claude-notifier-on-stop") &&
     hasHook("PermissionRequest", "claude-notifier-on-permission") &&
     hasHook("PreToolUse", "claude-notifier-on-question")
   ) {
-    return; // Already configured with correct runner, don't touch settings.json
+    return; // Already configured correctly, don't touch settings.json
   }
 
   if (!settings.hooks) {
@@ -211,10 +218,9 @@ function setupHooks(context: vscode.ExtensionContext) {
     hooks: [{ type: "command", command: hookCmd(PERMISSION_HOOK) }],
   });
 
-  // PreToolUse hook — question asked
+  // PreToolUse hook — tracks task start time for all tools, plays sound for AskUserQuestion
   if (!settings.hooks.PreToolUse) settings.hooks.PreToolUse = [];
   settings.hooks.PreToolUse.push({
-    matcher: "AskUserQuestion",
     hooks: [{ type: "command", command: hookCmd(QUESTION_HOOK) }],
   });
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,6 +13,7 @@ const QUESTION_HOOK = path.join(HOOKS_DIR, `claude-notifier-on-question${HOOK_EX
 const MUTE_FLAG = path.join(HOOKS_DIR, "claude-notifier-muted");
 const SIGNAL_FILE = path.join(HOOKS_DIR, "claude-signal");
 const CONFIG_FILE = path.join(HOOKS_DIR, "claude-notifier-config.json");
+const TASKSTART_FILE = path.join(HOOKS_DIR, "claude-notifier-taskstart");
 const SETTINGS_FILE = path.join(CLAUDE_DIR, "settings.json");
 
 function hookCmd(hookPath: string): string {
@@ -81,7 +82,9 @@ export function activate(context: vscode.ExtensionContext) {
 
 function updateStatusBar() {
   statusBarItem.text = soundEnabled ? "$(unmute) Claude" : "$(mute) Claude";
-  statusBarItem.tooltip = `Claude Notifier — sound ${soundEnabled ? "on" : "off"} (click to toggle)`;
+  const threshold = vscode.workspace.getConfiguration("claudeNotifier").get<number>("durationThreshold", 0);
+  const thresholdInfo = threshold > 0 ? ` | threshold: ${threshold}s` : "";
+  statusBarItem.tooltip = `Claude Notifier — sound ${soundEnabled ? "on" : "off"}${thresholdInfo} (click to toggle)`;
 }
 
 function syncConfig() {
@@ -99,6 +102,7 @@ function syncConfig() {
       level: cfg.get<string>("asksQuestion.level", "sound+popup"),
       sound: cfg.get<string>("asksQuestion.sound", "Funk"),
     },
+    durationThreshold: cfg.get<number>("durationThreshold", 0),
   };
   try {
     fs.mkdirSync(HOOKS_DIR, { recursive: true });
@@ -218,7 +222,7 @@ function setupHooks(context: vscode.ExtensionContext) {
 }
 
 function teardownHooks() {
-  for (const file of [STOP_HOOK, PERMISSION_HOOK, QUESTION_HOOK, SIGNAL_FILE, MUTE_FLAG, CONFIG_FILE]) {
+  for (const file of [STOP_HOOK, PERMISSION_HOOK, QUESTION_HOOK, SIGNAL_FILE, MUTE_FLAG, CONFIG_FILE, TASKSTART_FILE]) {
     try { fs.unlinkSync(file); } catch {}
   }
   // Clean up legacy and cross-platform hook files


### PR DESCRIPTION
## Summary

Closes #1

Adds a new `claudeNotifier.durationThreshold` VS Code setting (number, in seconds, default `0`). When set to a value > 0, **all** notification sounds (task completed, permission, and question) are suppressed until Claude has been working for at least that many seconds. If you're still watching the IDE, you don't need audio alerts.

### How it works

1. The PreToolUse hook fires on **every** tool invocation and writes a `Date.now()` timestamp to a marker file (`~/.claude/hooks/claude-notifier-taskstart`) — only on the first tool call per task (preserves the earliest timestamp)
2. All hooks (stop, permission, question) read the marker and compute `elapsed = now - startTime`
3. If `elapsed < threshold`, the sound and OS notification are skipped
4. The Stop hook cleans up the marker file after each task

### Caveat

Duration is measured from the **first tool use**, not from when the user submits a prompt. This means:
- For tasks where Claude uses tools (the vast majority), the threshold works as expected
- For pure text-only responses (no tool use at all), no marker is written and no sound plays when threshold > 0 — this is intentional since text-only responses are typically instant

### Changes

- `package.json` — new `durationThreshold` setting, version 2.2.0
- `src/extension.ts` — syncs threshold to config, cleans up marker file, shows threshold in status bar tooltip, PreToolUse hook fires for all tools (no matcher)
- `hook/claude-notifier-on-stop.js/.ps1` — reads marker, checks threshold, cleans up
- `hook/claude-notifier-on-permission.js/.ps1` — writes marker, checks threshold before sound
- `hook/claude-notifier-on-question.js/.ps1` — writes marker for all tools, checks threshold before sound (only plays sound for AskUserQuestion)
- `README.md` — documents the new setting

### Status bar

The existing mute toggle addresses the "quick toggle" part of the original request. The tooltip now also shows the configured threshold when > 0.

## Test plan

- [x] Set threshold to `10`, ask Claude a quick question (< 10s) → no sound
- [x] Set threshold to `10`, give Claude a long task (> 10s) → sound plays
- [x] Set threshold to `0` → all notifications fire as before
- [x] Verify auto-approved tools (no permission prompt) still write the marker correctly
- [x] `npm run compile` passes with no errors