### PR TITLE
Fix Windows hook scripts ignoring sound settings (v2.1.1)

### DIFF
--- a/hook/claude-notifier-on-notification.ps1
+++ b/hook/claude-notifier-on-notification.ps1
@@ -2,7 +2,7 @@
 # Plays sound when Claude sends a notification.
 $ErrorActionPreference = 'SilentlyContinue'
 
-$hooksDir = Join-Path ($env:USERPROFILE) '.claude' 'hooks'
+$hooksDir = $PSScriptRoot
 $muteFlag = Join-Path $hooksDir 'claude-notifier-muted'
 
 $raw = [Console]::In.ReadToEnd()

--- a/hook/claude-notifier-on-permission.ps1
+++ b/hook/claude-notifier-on-permission.ps1
@@ -2,7 +2,7 @@
 # Plays sound when Claude needs permission.
 $ErrorActionPreference = 'SilentlyContinue'
 
-$hooksDir = Join-Path ($env:USERPROFILE) '.claude' 'hooks'
+$hooksDir = $PSScriptRoot
 $muteFlag = Join-Path $hooksDir 'claude-notifier-muted'
 $configFile = Join-Path $hooksDir 'claude-notifier-config.json'
 

--- a/hook/claude-notifier-on-question.ps1
+++ b/hook/claude-notifier-on-question.ps1
@@ -2,7 +2,7 @@
 # Plays sound when Claude asks the user a question.
 $ErrorActionPreference = 'SilentlyContinue'
 
-$hooksDir = Join-Path ($env:USERPROFILE) '.claude' 'hooks'
+$hooksDir = $PSScriptRoot
 $muteFlag = Join-Path $hooksDir 'claude-notifier-muted'
 $configFile = Join-Path $hooksDir 'claude-notifier-config.json'
 

--- a/hook/claude-notifier-on-stop.ps1
+++ b/hook/claude-notifier-on-stop.ps1
@@ -2,7 +2,7 @@
 # Plays "task completed" or "question asked" sound when Claude finishes.
 $ErrorActionPreference = 'SilentlyContinue'
 
-$hooksDir = Join-Path ($env:USERPROFILE) '.claude' 'hooks'
+$hooksDir = $PSScriptRoot
 $muteFlag = Join-Path $hooksDir 'claude-notifier-muted'
 $configFile = Join-Path $hooksDir 'claude-notifier-config.json'
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "claude-notifier",
   "displayName": "Claude Notifier",
   "description": "Plays distinct sounds when Claude Code finishes a task or needs your input",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "icon": "media/icon.png",
   "publisher": "SingularityInc",
   "repository": {


### PR DESCRIPTION
Fixes #4

## Root cause
All PowerShell hook scripts used `$env:USERPROFILE` to build the path to
`claude-notifier-config.json`. When Claude Code spawns PowerShell with
`-NoProfile -NonInteractive`, this env var doesn't resolve correctly. The
`Get-Content` call fails silently (due to `SilentlyContinue`), leaving
`$config` null and forcing fallback to hardcoded defaults — so sounds and
popups fire regardless of what's configured in VS Code settings.

## Fix
Replace `$env:USERPROFILE` with `$PSScriptRoot` in all four hook scripts.
Since the scripts live in `~/.claude/hooks/`, `$PSScriptRoot` points directly
to that directory and works reliably in any PowerShell execution context.

## Files changed
- `hook/claude-notifier-on-stop.ps1`
- `hook/claude-notifier-on-question.ps1`
- `hook/claude-notifier-on-permission.ps1`
- `hook/claude-notifier-on-notification.ps1`
- `package.json` — bumped to v2.1.1
