### PR TITLE
refactor extension.ts for maintainability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.2.0] - 2026-04-03
+
+### Changed
+
+- Refactored `extension.ts` for contributor maintainability. Hook registrations are now driven by a `HOOKS` array (`HookDef` interface) — adding a new hook event requires a single entry in one place instead of changes across four functions. Notification levels extracted into a `LEVELS` const with a `Level` type to eliminate scattered string literals. `handleSignal` is now driven by a `SIGNAL_MAP` instead of repeated branches. `syncConfig` loops over `HOOKS` so default sounds are colocated with their hook definition. `getEventLevel` reads directly from VS Code config instead of disk.
+
 ## [2.1.1] - 2026-04-03
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "claude-notifier",
   "displayName": "Claude Notifier",
   "description": "Plays distinct sounds when Claude Code finishes a task or needs your input",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "icon": "media/icon.png",
   "publisher": "SingularityInc",
   "repository": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,18 +2,21 @@ import * as vscode from "vscode";
 import * as fs from "fs";
 import * as path from "path";
 
-const HOME = process.env.HOME || process.env.USERPROFILE || "~";
-const CLAUDE_DIR = path.join(HOME, ".claude");
-const HOOKS_DIR = path.join(CLAUDE_DIR, "hooks");
-const IS_WIN = process.platform === "win32";
-const HOOK_EXT = IS_WIN ? ".ps1" : ".js";
-const STOP_HOOK = path.join(HOOKS_DIR, `claude-notifier-on-stop${HOOK_EXT}`);
-const PERMISSION_HOOK = path.join(HOOKS_DIR, `claude-notifier-on-permission${HOOK_EXT}`);
-const QUESTION_HOOK = path.join(HOOKS_DIR, `claude-notifier-on-question${HOOK_EXT}`);
-const MUTE_FLAG = path.join(HOOKS_DIR, "claude-notifier-muted");
-const SIGNAL_FILE = path.join(HOOKS_DIR, "claude-signal");
-const CONFIG_FILE = path.join(HOOKS_DIR, "claude-notifier-config.json");
+// ---- Paths ----------------------------------------------------------------
+
+const HOME      = process.env.HOME || process.env.USERPROFILE || "~";
+const CLAUDE_DIR   = path.join(HOME, ".claude");
+const HOOKS_DIR    = path.join(CLAUDE_DIR, "hooks");
 const SETTINGS_FILE = path.join(CLAUDE_DIR, "settings.json");
+const CONFIG_FILE  = path.join(HOOKS_DIR, "claude-notifier-config.json");
+const MUTE_FLAG    = path.join(HOOKS_DIR, "claude-notifier-muted");
+const SIGNAL_FILE  = path.join(HOOKS_DIR, "claude-signal");
+
+// ---- Platform -------------------------------------------------------------
+
+const IS_WIN            = process.platform === "win32";
+const HOOK_EXT          = IS_WIN ? ".ps1" : ".js";
+const HOOK_RUNNER_PREFIX = IS_WIN ? "powershell" : "node";
 
 function hookCmd(hookPath: string): string {
   if (IS_WIN) {
@@ -22,24 +25,86 @@ function hookCmd(hookPath: string): string {
   return `node "${hookPath}"`;
 }
 
+// ---- Notification levels --------------------------------------------------
+
+const LEVELS = {
+  SOUND_POPUP: "sound+popup",
+  SOUND:       "sound",
+  POPUP:       "popup",
+  OFF:         "off",
+} as const;
+
+type Level = typeof LEVELS[keyof typeof LEVELS];
+
+// ---- Hook definitions -----------------------------------------------------
+// Add a new entry here to register a new hook. Everything else adapts automatically.
+
+interface HookDef {
+  file: string;          // filename in /hook/ and ~/.claude/hooks/
+  type: string;          // Claude Code hook type key (settings.json)
+  matcher?: string;      // optional PreToolUse matcher
+  eventKey: string;      // claudeNotifier.<eventKey>.level / .sound in VS Code settings
+  defaultSound: string;  // fallback sound preset
+}
+
+const HOOKS: HookDef[] = [
+  {
+    file:         `claude-notifier-on-stop${HOOK_EXT}`,
+    type:         "Stop",
+    eventKey:     "taskCompleted",
+    defaultSound: "Hero",
+  },
+  {
+    file:         `claude-notifier-on-permission${HOOK_EXT}`,
+    type:         "PermissionRequest",
+    eventKey:     "needsPermission",
+    defaultSound: "Glass",
+  },
+  {
+    file:         `claude-notifier-on-question${HOOK_EXT}`,
+    type:         "PreToolUse",
+    matcher:      "AskUserQuestion",
+    eventKey:     "asksQuestion",
+    defaultSound: "Funk",
+  },
+];
+
+// Hook types that may appear in settings.json (used for cleanup)
 const ALL_HOOK_TYPES = ["Stop", "PermissionRequest", "PreToolUse", "Notification"] as const;
+
+// ---- Signal map -----------------------------------------------------------
+// Maps the signal reason written by hook scripts to a VS Code notification.
+
+interface SignalEvent {
+  eventKey: string;
+  message:  string;
+}
+
+const SIGNAL_MAP: Record<string, SignalEvent> = {
+  input:    { eventKey: "needsPermission", message: "Claude needs your permission."      },
+  question: { eventKey: "asksQuestion",    message: "Claude is asking you a question."   },
+  done:     { eventKey: "taskCompleted",   message: "Claude has finished the task."      },
+};
+
+// ---- State ----------------------------------------------------------------
 
 let statusBarItem: vscode.StatusBarItem;
 let watcher: fs.FSWatcher | null = null;
 let soundEnabled = true;
 
+// ---- Remote audio ---------------------------------------------------------
+
 function playRemoteSound() {
   // In remote sessions, webview audio is blocked by Electron's autoplay policy.
   // Use the terminal bell instead — VS Code forwards BEL to the local client.
-  // Ensure terminal bell is enabled in VS Code settings.
   const bellConfig = vscode.workspace.getConfiguration("terminal.integrated");
   if (!bellConfig.get<boolean>("enableBell")) {
     bellConfig.update("enableBell", true, vscode.ConfigurationTarget.Global);
   }
-  vscode.commands.executeCommand("workbench.action.terminal.sendSequence", {
-    text: "\u0007",
-  });
+  vscode.commands.executeCommand("workbench.action.terminal.sendSequence", { text: "\u0007" });
 }
+
+// ---- Activation -----------------------------------------------------------
 
 export function activate(context: vscode.ExtensionContext) {
   setupHooks(context);
@@ -51,30 +116,22 @@ export function activate(context: vscode.ExtensionContext) {
     fs.writeFileSync(SIGNAL_FILE, "");
   }
 
-  statusBarItem = vscode.window.createStatusBarItem(
-    vscode.StatusBarAlignment.Right,
-    100
-  );
+  statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 100);
   statusBarItem.command = "claudeNotifier.toggleSound";
   updateStatusBar();
   statusBarItem.show();
   context.subscriptions.push(statusBarItem);
 
-  const toggleCmd = vscode.commands.registerCommand(
-    "claudeNotifier.toggleSound",
-    () => {
-      soundEnabled = !soundEnabled;
-      if (soundEnabled) {
-        try { fs.unlinkSync(MUTE_FLAG); } catch {}
-      } else {
-        fs.writeFileSync(MUTE_FLAG, "");
-      }
-      updateStatusBar();
-      vscode.window.showInformationMessage(
-        `Claude Notifier sound: ${soundEnabled ? "ON" : "OFF"}`
-      );
+  const toggleCmd = vscode.commands.registerCommand("claudeNotifier.toggleSound", () => {
+    soundEnabled = !soundEnabled;
+    if (soundEnabled) {
+      try { fs.unlinkSync(MUTE_FLAG); } catch {}
+    } else {
+      fs.writeFileSync(MUTE_FLAG, "");
     }
-  );
+    updateStatusBar();
+    vscode.window.showInformationMessage(`Claude Notifier sound: ${soundEnabled ? "ON" : "OFF"}`);
+  });
   context.subscriptions.push(toggleCmd);
 
   const configListener = vscode.workspace.onDidChangeConfiguration((e) => {
@@ -93,40 +150,37 @@ export function activate(context: vscode.ExtensionContext) {
 }
 
 function updateStatusBar() {
-  statusBarItem.text = soundEnabled ? "$(unmute) Claude" : "$(mute) Claude";
+  statusBarItem.text    = soundEnabled ? "$(unmute) Claude" : "$(mute) Claude";
   statusBarItem.tooltip = `Claude Notifier — sound ${soundEnabled ? "on" : "off"} (click to toggle)`;
 }
 
+// ---- Config sync ----------------------------------------------------------
+// Writes VS Code settings to disk so hook scripts can read them at runtime.
+
 function syncConfig() {
   const cfg = vscode.workspace.getConfiguration("claudeNotifier");
-  const config = {
-    taskCompleted: {
-      level: cfg.get<string>("taskCompleted.level", "sound+popup"),
-      sound: cfg.get<string>("taskCompleted.sound", "Hero"),
-    },
-    needsPermission: {
-      level: cfg.get<string>("needsPermission.level", "sound+popup"),
-      sound: cfg.get<string>("needsPermission.sound", "Glass"),
-    },
-    asksQuestion: {
-      level: cfg.get<string>("asksQuestion.level", "sound+popup"),
-      sound: cfg.get<string>("asksQuestion.sound", "Funk"),
-    },
-  };
+  const config = Object.fromEntries(
+    HOOKS.map((hook) => [
+      hook.eventKey,
+      {
+        level: cfg.get<string>(`${hook.eventKey}.level`, LEVELS.SOUND_POPUP),
+        sound: cfg.get<string>(`${hook.eventKey}.sound`, hook.defaultSound),
+      },
+    ])
+  );
   try {
     fs.mkdirSync(HOOKS_DIR, { recursive: true });
     fs.writeFileSync(CONFIG_FILE, JSON.stringify(config, null, 2) + "\n");
   } catch {}
 }
 
-function getEventLevel(eventKey: string): string {
-  try {
-    const config = JSON.parse(fs.readFileSync(CONFIG_FILE, "utf-8"));
-    return config[eventKey]?.level ?? "sound+popup";
-  } catch {
-    return "sound+popup";
-  }
+function getEventLevel(eventKey: string): Level {
+  return vscode.workspace
+    .getConfiguration("claudeNotifier")
+    .get<Level>(`${eventKey}.level`, LEVELS.SOUND_POPUP);
 }
+
+// ---- Signal handling ------------------------------------------------------
 
 function handleSignal() {
   let content = "";
@@ -137,121 +191,88 @@ function handleSignal() {
   }
 
   const reason = content.split(" ")[0];
-  // When running on a remote host the extension process is on the server and
-  // cannot play audio. VS Code webviews always render in the local renderer, so
-  // we synthesize a tone there instead.
+  const event  = SIGNAL_MAP[reason];
+  if (!event) return;
+
+  const level    = getEventLevel(event.eventKey);
   const isRemote = !!vscode.env.remoteName;
 
-  if (reason === "input") {
-    const level = getEventLevel("needsPermission");
-    if (isRemote && (level === "sound+popup" || level === "sound")) {
-      playRemoteSound();
-    }
-    if (level === "sound+popup" || level === "popup") {
-      vscode.window.showInformationMessage("Claude needs your permission.");
-    }
-  } else if (reason === "question") {
-    const level = getEventLevel("asksQuestion");
-    if (isRemote && (level === "sound+popup" || level === "sound")) {
-      playRemoteSound();
-    }
-    if (level === "sound+popup" || level === "popup") {
-      vscode.window.showInformationMessage("Claude is asking you a question.");
-    }
-  } else if (reason === "done") {
-    const level = getEventLevel("taskCompleted");
-    if (isRemote && (level === "sound+popup" || level === "sound")) {
-      playRemoteSound();
-    }
-    if (level === "sound+popup" || level === "popup") {
-      vscode.window.showInformationMessage("Claude has finished the task.");
-    }
+  if (isRemote && (level === LEVELS.SOUND_POPUP || level === LEVELS.SOUND)) {
+    playRemoteSound();
+  }
+  if (level === LEVELS.SOUND_POPUP || level === LEVELS.POPUP) {
+    vscode.window.showInformationMessage(event.message);
   }
 }
 
-// --- Hook lifecycle ---
+// ---- Hook lifecycle -------------------------------------------------------
 
 function setupHooks(context: vscode.ExtensionContext) {
   fs.mkdirSync(HOOKS_DIR, { recursive: true });
 
-  // Copy bundled hook scripts (only if changed)
-  for (const [bundled, dest] of [
-    [`claude-notifier-on-stop${HOOK_EXT}`, STOP_HOOK],
-    [`claude-notifier-on-permission${HOOK_EXT}`, PERMISSION_HOOK],
-    [`claude-notifier-on-question${HOOK_EXT}`, QUESTION_HOOK],
-  ]) {
-    const src = path.join(context.extensionPath, "hook", bundled);
+  // Copy bundled hook scripts to ~/.claude/hooks/ (only if changed)
+  for (const hook of HOOKS) {
+    const src  = path.join(context.extensionPath, "hook", hook.file);
+    const dest = path.join(HOOKS_DIR, hook.file);
     const srcContent = fs.readFileSync(src, "utf-8");
-    let destContent = "";
+    let destContent  = "";
     try { destContent = fs.readFileSync(dest, "utf-8"); } catch {}
     if (srcContent !== destContent) {
       fs.writeFileSync(dest, srcContent, { mode: 0o755 });
     }
   }
 
-  // Check if our hooks are already configured with the right runner — skip if so
   const settings = readSettings();
-  const expectedPrefix = IS_WIN ? "powershell" : "node";
-  const hasHook = (type: string, needle: string) =>
-    settings.hooks?.[type]?.some((entry: any) =>
-      entry.hooks?.some((h: any) => h.command?.includes(needle) && h.command?.startsWith(expectedPrefix))
-    );
 
-  if (
-    hasHook("Stop", "claude-notifier-on-stop") &&
-    hasHook("PermissionRequest", "claude-notifier-on-permission") &&
-    hasHook("PreToolUse", "claude-notifier-on-question")
-  ) {
-    return; // Already configured with correct runner, don't touch settings.json
-  }
+  // Skip settings.json write if all hooks are already registered with the correct runner
+  const allConfigured = HOOKS.every((hook) =>
+    settings.hooks?.[hook.type]?.some((entry: any) =>
+      entry.hooks?.some((h: any) =>
+        h.command?.includes(hook.file) && h.command?.startsWith(HOOK_RUNNER_PREFIX)
+      )
+    )
+  );
+  if (allConfigured) return;
 
-  if (!settings.hooks) {
-    settings.hooks = {};
-  }
+  if (!settings.hooks) settings.hooks = {};
 
-  // Remove stale claude-notifier entries
+  // Remove stale claude-notifier entries before re-registering
   for (const hookType of ALL_HOOK_TYPES) {
     if (settings.hooks[hookType]) {
       settings.hooks[hookType] = settings.hooks[hookType].filter(
         (entry: any) => !entry.hooks?.some((h: any) => h.command?.includes("claude-notifier"))
       );
-      if (settings.hooks[hookType].length === 0) {
-        delete settings.hooks[hookType];
-      }
+      if (settings.hooks[hookType].length === 0) delete settings.hooks[hookType];
     }
   }
 
-  // Stop hook — task completed
-  if (!settings.hooks.Stop) settings.hooks.Stop = [];
-  settings.hooks.Stop.push({
-    hooks: [{ type: "command", command: hookCmd(STOP_HOOK) }],
-  });
-
-  // PermissionRequest hook — needs permission
-  if (!settings.hooks.PermissionRequest) settings.hooks.PermissionRequest = [];
-  settings.hooks.PermissionRequest.push({
-    hooks: [{ type: "command", command: hookCmd(PERMISSION_HOOK) }],
-  });
-
-  // PreToolUse hook — question asked
-  if (!settings.hooks.PreToolUse) settings.hooks.PreToolUse = [];
-  settings.hooks.PreToolUse.push({
-    matcher: "AskUserQuestion",
-    hooks: [{ type: "command", command: hookCmd(QUESTION_HOOK) }],
-  });
+  // Register each hook
+  for (const hook of HOOKS) {
+    const dest  = path.join(HOOKS_DIR, hook.file);
+    const entry: any = { hooks: [{ type: "command", command: hookCmd(dest) }] };
+    if (hook.matcher) entry.matcher = hook.matcher;
+    if (!settings.hooks[hook.type]) settings.hooks[hook.type] = [];
+    settings.hooks[hook.type].push(entry);
+  }
 
   writeSettings(settings);
 }
 
 function teardownHooks() {
-  for (const file of [STOP_HOOK, PERMISSION_HOOK, QUESTION_HOOK, SIGNAL_FILE, MUTE_FLAG, CONFIG_FILE]) {
+  // Remove all hook files (current platform + legacy cross-platform variants)
+  const legacyNames = [
+    "claude-notifier-on-stop",
+    "claude-notifier-on-permission",
+    "claude-notifier-on-question",
+    "claude-notifier-on-notification",
+  ];
+  const legacyFiles = legacyNames.flatMap((name) =>
+    [".js", ".ps1", ".sh"].map((ext) => path.join(HOOKS_DIR, `${name}${ext}`))
+  );
+  const activeFiles = HOOKS.map((hook) => path.join(HOOKS_DIR, hook.file));
+
+  for (const file of [SIGNAL_FILE, MUTE_FLAG, CONFIG_FILE, ...activeFiles, ...legacyFiles]) {
     try { fs.unlinkSync(file); } catch {}
-  }
-  // Clean up legacy and cross-platform hook files
-  for (const name of ["claude-notifier-on-stop", "claude-notifier-on-permission", "claude-notifier-on-question", "claude-notifier-on-notification"]) {
-    for (const ext of [".js", ".ps1", ".sh"]) {
-      try { fs.unlinkSync(path.join(HOOKS_DIR, `${name}${ext}`)); } catch {}
-    }
   }
 
   const settings = readSettings();
@@ -260,16 +281,14 @@ function teardownHooks() {
       settings.hooks[hookType] = settings.hooks[hookType].filter(
         (entry: any) => !entry.hooks?.some((h: any) => h.command?.includes("claude-notifier"))
       );
-      if (settings.hooks[hookType].length === 0) {
-        delete settings.hooks[hookType];
-      }
+      if (settings.hooks[hookType].length === 0) delete settings.hooks[hookType];
     }
   }
-  if (settings.hooks && Object.keys(settings.hooks).length === 0) {
-    delete settings.hooks;
-  }
+  if (settings.hooks && Object.keys(settings.hooks).length === 0) delete settings.hooks;
   writeSettings(settings);
 }
+
+// ---- Settings helpers -----------------------------------------------------
 
 function readSettings(): any {
   try {
@@ -283,6 +302,8 @@ function writeSettings(settings: any) {
   fs.mkdirSync(path.dirname(SETTINGS_FILE), { recursive: true });
   fs.writeFileSync(SETTINGS_FILE, JSON.stringify(settings, null, 2) + "\n");
 }
+
+// ---- Deactivation ---------------------------------------------------------
 
 export function deactivate() {
   if (watcher) {


### PR DESCRIPTION
- Replace hardcoded hook registrations with a HOOKS array (HookDef interface) so adding a new hook event requires a single entry in one place
- Add LEVELS const and Level type to eliminate scattered string literals
- Add SIGNAL_MAP to drive handleSignal generically instead of repeated branches
- syncConfig now loops over HOOKS; default sounds colocated with hook definitions
- getEventLevel reads from vscode config directly instead of disk
- Group constants by concern with section comments