### PR TITLE
Addresses two coordination bugs in the extension↔hook active-flag protocol introduced in #10:

### DIFF
--- a/hook/claude-notifier-on-question.js
+++ b/hook/claude-notifier-on-question.js
@@ -47,6 +47,9 @@ process.stdin.on("end", () => {
   let input = {};
   try { input = JSON.parse(raw); } catch { process.exit(0); }
 
+  // Defense-in-depth: bail if a misconfigured matcher routes other tools here.
+  if (input.tool_name !== "AskUserQuestion") process.exit(0);
+
   if (fs.existsSync(MUTE_FLAG)) process.exit(0);
 
   const config = readConfig();

--- a/hook/claude-notifier-on-question.ps1
+++ b/hook/claude-notifier-on-question.ps1
@@ -20,6 +20,9 @@ $winSounds = @{
 $raw = [Console]::In.ReadToEnd()
 try { $data = $raw | ConvertFrom-Json } catch { exit 0 }
 
+# Defense-in-depth: bail if a misconfigured matcher routes other tools here.
+if ($data.tool_name -ne 'AskUserQuestion') { exit 0 }
+
 if (Test-Path $muteFlag) { exit 0 }
 
 # Read config

--- a/hook/claude-notifier-on-stop.js
+++ b/hook/claude-notifier-on-stop.js
@@ -1,12 +1,17 @@
 #!/usr/bin/env node
-// Claude Notifier — Stop hook script (v2)
-// Plays "task completed" or "question asked" sound when Claude finishes.
+// Claude Notifier — Stop hook script (v3)
+// Writes a "done" signal for the VSCode extension to debounce. When no
+// extension is active (terminal-only), plays sound/notification directly as
+// a fallback. The extension writes a claude-notifier-active marker file so
+// the hook knows to defer to it.
 const fs = require("fs");
 const path = require("path");
 const { execSync } = require("child_process");
 
 const HOOKS_DIR = path.join(process.env.HOME || process.env.USERPROFILE || "~", ".claude", "hooks");
 const MUTE_FLAG = path.join(HOOKS_DIR, "claude-notifier-muted");
+const SIGNAL_FILE = path.join(HOOKS_DIR, "claude-signal");
+const ACTIVE_FLAG = path.join(HOOKS_DIR, "claude-notifier-active");
 const IS_WIN = process.platform === "win32";
 const IS_WSL = !IS_WIN && process.platform === "linux" && (() => {
   try { return fs.readFileSync("/proc/version", "utf-8").toLowerCase().includes("microsoft"); } catch { return false; }
@@ -40,16 +45,6 @@ function readConfig() {
   catch { return null; }
 }
 
-const DEFAULT_SOUNDS = {
-  question: { mac: "/System/Library/Sounds/Pop.aiff", win: "C:\\Windows\\Media\\Windows Notify.wav" },
-  done: { mac: "/System/Library/Sounds/Hero.aiff", win: "C:\\Windows\\Media\\tada.wav" },
-};
-
-const MESSAGES = {
-  question: "Claude is asking you a question.",
-  done: "Claude has finished the task.",
-};
-
 let raw = "";
 process.stdin.setEncoding("utf-8");
 process.stdin.on("data", (chunk) => (raw += chunk));
@@ -60,40 +55,23 @@ process.stdin.on("end", () => {
   if (input.stop_hook_active) process.exit(0);
   if (fs.existsSync(MUTE_FLAG)) process.exit(0);
 
-  let reason = "done";
-  const transcript = input.transcript_path || "";
+  // Write signal for the VSCode extension (which debounces "done" signals).
+  try {
+    fs.writeFileSync(SIGNAL_FILE, "done " + Date.now());
+  } catch {}
 
-  if (transcript && fs.existsSync(transcript)) {
-    try {
-      const data = fs.readFileSync(transcript, "utf-8").trim();
-      const lines = data.split("\n").slice(-20);
-      for (let i = lines.length - 1; i >= 0; i--) {
-        try {
-          const msg = JSON.parse(lines[i]);
-          if (msg.role === "assistant" && Array.isArray(msg.content) && msg.content.length > 0) {
-            const last = msg.content[msg.content.length - 1];
-            if (last.type === "tool_use" && last.name === "AskUserQuestion") {
-              reason = "question";
-            } else if (last.type === "text" && last.text && last.text.trim().endsWith("?")) {
-              reason = "question";
-            }
-            break;
-          }
-        } catch {}
-      }
-    } catch {}
-  }
+  // If the extension is active it handles sound/notification with debounce.
+  // Only play directly when running in terminal without the extension.
+  if (fs.existsSync(ACTIVE_FLAG)) process.exit(0);
 
   const config = readConfig();
-  const configKey = reason === "question" ? "asksQuestion" : "taskCompleted";
-  const eventCfg = config?.[configKey] ?? {};
+  const eventCfg = config?.taskCompleted ?? {};
   const level = eventCfg.level ?? "sound+popup";
 
   if (level === "off") process.exit(0);
 
-  const sound = resolveSound(eventCfg.sound, DEFAULT_SOUNDS[reason].mac, DEFAULT_SOUNDS[reason].win);
+  const sound = resolveSound(eventCfg.sound, "/System/Library/Sounds/Hero.aiff", "C:\\Windows\\Media\\tada.wav");
 
-  // Play sound
   if (level === "sound+popup" || level === "sound") {
     try {
       if (USE_WIN) {
@@ -105,24 +83,16 @@ process.stdin.on("end", () => {
     } catch {}
   }
 
-  // OS notification
-  const message = MESSAGES[reason];
   if (level === "sound+popup" || level === "popup") {
     try {
       if (USE_WIN) {
-        const safeMsg = message.replace(/'/g, "''");
-        const ps = `Add-Type -AssemblyName System.Windows.Forms; $n=New-Object System.Windows.Forms.NotifyIcon; $n.Icon=[System.Drawing.SystemIcons]::Information; $n.Visible=$true; $n.ShowBalloonTip(3000,'Claude Notifier','${safeMsg}',[System.Windows.Forms.ToolTipIcon]::None); Start-Sleep -m 500; $n.Dispose()`;
+        const ps = `Add-Type -AssemblyName System.Windows.Forms; $n=New-Object System.Windows.Forms.NotifyIcon; $n.Icon=[System.Drawing.SystemIcons]::Information; $n.Visible=$true; $n.ShowBalloonTip(3000,'Claude Notifier','Claude has finished the task.',[System.Windows.Forms.ToolTipIcon]::None); Start-Sleep -m 500; $n.Dispose()`;
         execSync(`${PS_BIN} -NoProfile -NonInteractive -EncodedCommand ${Buffer.from(ps, "utf16le").toString("base64")}`, { stdio: "ignore", timeout: 5000 });
       } else {
-        execSync(`osascript -e 'display notification "${message}" with title "Claude Notifier"'`, { stdio: "ignore" });
+        execSync(`osascript -e 'display notification "Claude has finished the task." with title "Claude Notifier"'`, { stdio: "ignore" });
       }
     } catch {}
   }
-
-  // Write signal for VSCode extension
-  try {
-    fs.writeFileSync(path.join(HOOKS_DIR, "claude-signal"), reason + " " + Date.now());
-  } catch {}
 
   process.exit(0);
 });

--- a/hook/claude-notifier-on-stop.js
+++ b/hook/claude-notifier-on-stop.js
@@ -2,8 +2,9 @@
 // Claude Notifier — Stop hook script (v3)
 // Writes a "done" signal for the VSCode extension to debounce. When no
 // extension is active (terminal-only), plays sound/notification directly as
-// a fallback. The extension writes a claude-notifier-active marker file so
-// the hook knows to defer to it.
+// a fallback. Each active extension window writes a PID marker file into
+// claude-notifier-active.d/; the hook only defers when a marker names a
+// live process, so a crashed extension doesn't silence terminal fallback.
 const fs = require("fs");
 const path = require("path");
 const { execSync } = require("child_process");
@@ -11,7 +12,18 @@ const { execSync } = require("child_process");
 const HOOKS_DIR = path.join(process.env.HOME || process.env.USERPROFILE || "~", ".claude", "hooks");
 const MUTE_FLAG = path.join(HOOKS_DIR, "claude-notifier-muted");
 const SIGNAL_FILE = path.join(HOOKS_DIR, "claude-signal");
-const ACTIVE_FLAG = path.join(HOOKS_DIR, "claude-notifier-active");
+const ACTIVE_DIR = path.join(HOOKS_DIR, "claude-notifier-active.d");
+
+function extensionIsActive() {
+  let entries;
+  try { entries = fs.readdirSync(ACTIVE_DIR); } catch { return false; }
+  for (const name of entries) {
+    const pid = parseInt(name, 10);
+    if (!Number.isFinite(pid)) continue;
+    try { process.kill(pid, 0); return true; } catch {}
+  }
+  return false;
+}
 const IS_WIN = process.platform === "win32";
 const IS_WSL = !IS_WIN && process.platform === "linux" && (() => {
   try { return fs.readFileSync("/proc/version", "utf-8").toLowerCase().includes("microsoft"); } catch { return false; }
@@ -62,7 +74,7 @@ process.stdin.on("end", () => {
 
   // If the extension is active it handles sound/notification with debounce.
   // Only play directly when running in terminal without the extension.
-  if (fs.existsSync(ACTIVE_FLAG)) process.exit(0);
+  if (extensionIsActive()) process.exit(0);
 
   const config = readConfig();
   const eventCfg = config?.taskCompleted ?? {};

--- a/hook/claude-notifier-on-stop.ps1
+++ b/hook/claude-notifier-on-stop.ps1
@@ -6,8 +6,22 @@ $ErrorActionPreference = 'SilentlyContinue'
 $hooksDir = $PSScriptRoot
 $muteFlag = Join-Path $hooksDir 'claude-notifier-muted'
 $signalFile = Join-Path $hooksDir 'claude-signal'
-$activeFlag = Join-Path $hooksDir 'claude-notifier-active'
+$activeDir  = Join-Path $hooksDir 'claude-notifier-active.d'
 $configFile = Join-Path $hooksDir 'claude-notifier-config.json'
+
+# Extension writes one PID marker file per window into $activeDir. Only
+# treat the extension as active when a marker names a live process, so a
+# stale marker from a crashed window doesn't silence terminal fallback.
+function Test-ExtensionActive {
+    if (-not (Test-Path $activeDir)) { return $false }
+    foreach ($f in Get-ChildItem -Path $activeDir -File -ErrorAction SilentlyContinue) {
+        $pidVal = 0
+        if ([int]::TryParse($f.Name, [ref]$pidVal)) {
+            if (Get-Process -Id $pidVal -ErrorAction SilentlyContinue) { return $true }
+        }
+    }
+    return $false
+}
 
 $winSounds = @{
     'Windows Notify' = 'C:\Windows\Media\Windows Notify.wav'
@@ -33,7 +47,7 @@ try {
 
 # If the extension is active it handles sound/notification with debounce.
 # Only play directly when running in terminal without the extension.
-if (Test-Path $activeFlag) { exit 0 }
+if (Test-ExtensionActive) { exit 0 }
 
 $config = $null
 try { $config = (Get-Content $configFile -Raw) | ConvertFrom-Json } catch {}

--- a/hook/claude-notifier-on-stop.ps1
+++ b/hook/claude-notifier-on-stop.ps1
@@ -1,9 +1,12 @@
-# Claude Notifier - Stop hook (PowerShell, v2)
-# Plays "task completed" or "question asked" sound when Claude finishes.
+# Claude Notifier - Stop hook (PowerShell, v3)
+# Writes a "done" signal for the VSCode extension to debounce. When no
+# extension is active (terminal-only), plays sound/notification directly.
 $ErrorActionPreference = 'SilentlyContinue'
 
 $hooksDir = $PSScriptRoot
 $muteFlag = Join-Path $hooksDir 'claude-notifier-muted'
+$signalFile = Join-Path $hooksDir 'claude-signal'
+$activeFlag = Join-Path $hooksDir 'claude-notifier-active'
 $configFile = Join-Path $hooksDir 'claude-notifier-config.json'
 
 $winSounds = @{
@@ -23,46 +26,26 @@ try { $data = $raw | ConvertFrom-Json } catch { exit 0 }
 if ($data.stop_hook_active) { exit 0 }
 if (Test-Path $muteFlag) { exit 0 }
 
-$reason = 'done'
+# Write signal for the VSCode extension (which debounces "done" signals).
+try {
+    Set-Content -Path $signalFile -Value "done $(Get-Date -UFormat %s)" -NoNewline
+} catch {}
 
-$transcript = $data.transcript_path
-if ($transcript -and (Test-Path $transcript)) {
-    try {
-        $lines = Get-Content $transcript -Tail 20
-        for ($i = $lines.Count - 1; $i -ge 0; $i--) {
-            try {
-                $msg = $lines[$i] | ConvertFrom-Json
-                if ($msg.role -eq 'assistant' -and $msg.content -and $msg.content.Count -gt 0) {
-                    $last = $msg.content[$msg.content.Count - 1]
-                    if ($last.type -eq 'tool_use' -and $last.name -eq 'AskUserQuestion') {
-                        $reason = 'question'
-                    } elseif ($last.type -eq 'text' -and $last.text -and $last.text.Trim().EndsWith('?')) {
-                        $reason = 'question'
-                    }
-                    break
-                }
-            } catch {}
-        }
-    } catch {}
-}
+# If the extension is active it handles sound/notification with debounce.
+# Only play directly when running in terminal without the extension.
+if (Test-Path $activeFlag) { exit 0 }
 
-# Read config
 $config = $null
 try { $config = (Get-Content $configFile -Raw) | ConvertFrom-Json } catch {}
 
-$configKey = if ($reason -eq 'question') { 'asksQuestion' } else { 'taskCompleted' }
-$eventCfg = if ($config -and $config.$configKey) { $config.$configKey } else { $null }
+$eventCfg = if ($config -and $config.taskCompleted) { $config.taskCompleted } else { $null }
 $level = if ($eventCfg -and $eventCfg.level) { $eventCfg.level } else { 'sound+popup' }
 
 if ($level -eq 'off') { exit 0 }
 
-$defaultSounds = @{ question = 'C:\Windows\Media\Windows Notify.wav'; done = 'C:\Windows\Media\tada.wav' }
 $soundName = if ($eventCfg -and $eventCfg.sound) { $eventCfg.sound } else { '' }
-$soundPath = if ($winSounds.ContainsKey($soundName)) { $winSounds[$soundName] } else { $defaultSounds[$reason] }
+$soundPath = if ($winSounds.ContainsKey($soundName)) { $winSounds[$soundName] } else { 'C:\Windows\Media\tada.wav' }
 
-$messages = @{ question = 'Claude is asking you a question.'; done = 'Claude has finished the task.' }
-
-# Play sound
 if ($level -eq 'sound+popup' -or $level -eq 'sound') {
     try {
         if (Test-Path $soundPath) { (New-Object Media.SoundPlayer $soundPath).PlaySync() }
@@ -70,20 +53,14 @@ if ($level -eq 'sound+popup' -or $level -eq 'sound') {
     } catch {}
 }
 
-# OS notification
 if ($level -eq 'sound+popup' -or $level -eq 'popup') {
     try {
         Add-Type -AssemblyName System.Windows.Forms
         $n = New-Object System.Windows.Forms.NotifyIcon
         $n.Icon = [System.Drawing.SystemIcons]::Information
         $n.Visible = $true
-        $n.ShowBalloonTip(3000, 'Claude Notifier', $messages[$reason], [System.Windows.Forms.ToolTipIcon]::None)
+        $n.ShowBalloonTip(3000, 'Claude Notifier', 'Claude has finished the task.', [System.Windows.Forms.ToolTipIcon]::None)
         Start-Sleep -Milliseconds 500
         $n.Dispose()
     } catch {}
 }
-
-# Write signal for VSCode extension
-try {
-    Set-Content -Path (Join-Path $hooksDir 'claude-signal') -Value "$reason $(Get-Date -UFormat %s)" -NoNewline
-} catch {}

--- a/package.json
+++ b/package.json
@@ -78,6 +78,13 @@
           "enum": ["Basso", "Blow", "Bottle", "Frog", "Funk", "Glass", "Hero", "Morse", "Ping", "Pop", "Purr", "Sosumi", "Submarine", "Tink", "Windows Notify", "tada", "chimes", "chord", "ding", "notify", "ringin", "Windows Background"],
           "default": "Funk",
           "description": "Sound preset when Claude asks a question. macOS: Basso–Tink. Windows: Windows Notify–Windows Background."
+        },
+        "claudeNotifier.doneDebounceMs": {
+          "type": "number",
+          "default": 2000,
+          "minimum": 0,
+          "maximum": 10000,
+          "description": "Milliseconds to wait after a 'done' signal before notifying. Collapses rapid subtask Stop events into a single notification. Lower = snappier; higher = safer against duplicates."
         }
       }
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -192,15 +192,16 @@ function setupHooks(context: vscode.ExtensionContext) {
   // Check if our hooks are already configured with the right runner — skip if so
   const settings = readSettings();
   const expectedPrefix = IS_WIN ? "powershell" : "node";
-  const hasHook = (type: string, needle: string) =>
+  const hasHook = (type: string, needle: string, matcher?: string) =>
     settings.hooks?.[type]?.some((entry: any) =>
+      (matcher === undefined || entry.matcher === matcher) &&
       entry.hooks?.some((h: any) => h.command?.includes(needle) && h.command?.startsWith(expectedPrefix))
     );
 
   if (
     hasHook("Stop", "claude-notifier-on-stop") &&
     hasHook("PermissionRequest", "claude-notifier-on-permission") &&
-    hasHook("PreToolUse", "claude-notifier-on-question")
+    hasHook("PreToolUse", "claude-notifier-on-question", "AskUserQuestion")
   ) {
     return; // Already configured with correct runner, don't touch settings.json
   }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,7 +13,12 @@ const PERMISSION_HOOK = path.join(HOOKS_DIR, `claude-notifier-on-permission${HOO
 const QUESTION_HOOK = path.join(HOOKS_DIR, `claude-notifier-on-question${HOOK_EXT}`);
 const MUTE_FLAG = path.join(HOOKS_DIR, "claude-notifier-muted");
 const SIGNAL_FILE = path.join(HOOKS_DIR, "claude-signal");
-const ACTIVE_FLAG = path.join(HOOKS_DIR, "claude-notifier-active");
+// Directory of per-PID marker files. Hooks treat the extension as active if
+// any marker inside corresponds to a live PID. Using a directory (instead of a
+// single flag file) lets multiple VSCode windows coexist and survives crashes:
+// stale markers get cleaned up on next activate and ignored via PID liveness.
+const ACTIVE_DIR = path.join(HOOKS_DIR, "claude-notifier-active.d");
+const OWN_PID_FILE = path.join(ACTIVE_DIR, String(process.pid));
 const CONFIG_FILE = path.join(HOOKS_DIR, "claude-notifier-config.json");
 const SETTINGS_FILE = path.join(CLAUDE_DIR, "settings.json");
 
@@ -68,6 +73,31 @@ let watcher: fs.FSWatcher | null = null;
 let soundEnabled = true;
 let doneDebounceTimer: ReturnType<typeof setTimeout> | null = null;
 
+function isPidAlive(pid: number): boolean {
+  try { process.kill(pid, 0); return true; } catch { return false; }
+}
+
+function cleanStalePidFiles() {
+  try {
+    for (const name of fs.readdirSync(ACTIVE_DIR)) {
+      const pid = parseInt(name, 10);
+      if (!Number.isFinite(pid) || !isPidAlive(pid)) {
+        try { fs.unlinkSync(path.join(ACTIVE_DIR, name)); } catch {}
+      }
+    }
+  } catch {}
+}
+
+function hasOtherActiveInstances(): boolean {
+  try {
+    for (const name of fs.readdirSync(ACTIVE_DIR)) {
+      const pid = parseInt(name, 10);
+      if (Number.isFinite(pid) && pid !== process.pid && isPidAlive(pid)) return true;
+    }
+  } catch {}
+  return false;
+}
+
 function playRemoteSound() {
   // In remote sessions, webview audio is blocked by Electron's autoplay policy.
   // Use the terminal bell instead — VS Code forwards BEL to the local client.
@@ -85,10 +115,15 @@ export function activate(context: vscode.ExtensionContext) {
   setupHooks(context);
   syncConfig();
 
-  // Signal to hook scripts that the extension is running and will handle
-  // "done" sound/notification with debounce. Without this flag, hooks play
-  // sounds directly as a fallback for terminal-only users.
-  try { fs.writeFileSync(ACTIVE_FLAG, String(process.pid)); } catch {}
+  // Register this window as an active instance so hook scripts defer
+  // "done" sound/notification to the extension (which debounces). Each
+  // window writes its own PID file; hooks verify liveness before deferring,
+  // so stale markers from crashed windows never block terminal fallback.
+  try {
+    fs.mkdirSync(ACTIVE_DIR, { recursive: true });
+    cleanStalePidFiles();
+    fs.writeFileSync(OWN_PID_FILE, "");
+  } catch {}
 
   soundEnabled = !fs.existsSync(MUTE_FLAG);
 
@@ -328,9 +363,10 @@ function setupHooks(context: vscode.ExtensionContext) {
 }
 
 function teardownHooks() {
-  for (const file of [STOP_HOOK, PERMISSION_HOOK, QUESTION_HOOK, SIGNAL_FILE, MUTE_FLAG, CONFIG_FILE, ACTIVE_FLAG]) {
+  for (const file of [STOP_HOOK, PERMISSION_HOOK, QUESTION_HOOK, SIGNAL_FILE, MUTE_FLAG, CONFIG_FILE]) {
     try { fs.unlinkSync(file); } catch {}
   }
+  try { fs.rmdirSync(ACTIVE_DIR); } catch {}
   // Clean up legacy and cross-platform hook files
   for (const name of ["claude-notifier-on-stop", "claude-notifier-on-permission", "claude-notifier-on-question", "claude-notifier-on-notification"]) {
     for (const ext of [".js", ".ps1", ".sh"]) {
@@ -373,6 +409,11 @@ export function deactivate() {
     watcher.close();
     watcher = null;
   }
-  try { fs.unlinkSync(ACTIVE_FLAG); } catch {}
-  teardownHooks();
+  // Remove our PID marker first, then only tear down shared state if no
+  // other VSCode windows are still running the extension — otherwise we'd
+  // pull hook scripts and config out from under them.
+  try { fs.unlinkSync(OWN_PID_FILE); } catch {}
+  if (!hasOtherActiveInstances()) {
+    teardownHooks();
+  }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -227,12 +227,15 @@ function handleSignal() {
 
   if (reason === "done") {
     // Debounce "done" signals — Claude fires Stop hooks between subtasks.
-    // Only notify after 3 seconds of silence (no new signals).
+    // Only notify after N ms of silence (no new signals).
+    const debounceMs = vscode.workspace
+      .getConfiguration("claudeNotifier")
+      .get<number>("doneDebounceMs", 2000);
     if (doneDebounceTimer) clearTimeout(doneDebounceTimer);
     doneDebounceTimer = setTimeout(() => {
       doneDebounceTimer = null;
       showNotification("done");
-    }, 3000);
+    }, debounceMs);
   } else {
     // "question" and "input" signals are immediate — user action is needed.
     // Cancel any pending "done" notification (the stop after a question is expected).

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,7 @@
 import * as vscode from "vscode";
 import * as fs from "fs";
 import * as path from "path";
+import { exec } from "child_process";
 
 const HOME = process.env.HOME || process.env.USERPROFILE || "~";
 const CLAUDE_DIR = path.join(HOME, ".claude");
@@ -12,8 +13,46 @@ const PERMISSION_HOOK = path.join(HOOKS_DIR, `claude-notifier-on-permission${HOO
 const QUESTION_HOOK = path.join(HOOKS_DIR, `claude-notifier-on-question${HOOK_EXT}`);
 const MUTE_FLAG = path.join(HOOKS_DIR, "claude-notifier-muted");
 const SIGNAL_FILE = path.join(HOOKS_DIR, "claude-signal");
+const ACTIVE_FLAG = path.join(HOOKS_DIR, "claude-notifier-active");
 const CONFIG_FILE = path.join(HOOKS_DIR, "claude-notifier-config.json");
 const SETTINGS_FILE = path.join(CLAUDE_DIR, "settings.json");
+
+const MACOS_SOUNDS: Record<string, string> = {
+  Basso: "/System/Library/Sounds/Basso.aiff", Blow: "/System/Library/Sounds/Blow.aiff",
+  Bottle: "/System/Library/Sounds/Bottle.aiff", Frog: "/System/Library/Sounds/Frog.aiff",
+  Funk: "/System/Library/Sounds/Funk.aiff", Glass: "/System/Library/Sounds/Glass.aiff",
+  Hero: "/System/Library/Sounds/Hero.aiff", Morse: "/System/Library/Sounds/Morse.aiff",
+  Ping: "/System/Library/Sounds/Ping.aiff", Pop: "/System/Library/Sounds/Pop.aiff",
+  Purr: "/System/Library/Sounds/Purr.aiff", Sosumi: "/System/Library/Sounds/Sosumi.aiff",
+  Submarine: "/System/Library/Sounds/Submarine.aiff", Tink: "/System/Library/Sounds/Tink.aiff",
+};
+const WIN_SOUNDS: Record<string, string> = {
+  "Windows Notify": "C:\\Windows\\Media\\Windows Notify.wav", "tada": "C:\\Windows\\Media\\tada.wav",
+  "chimes": "C:\\Windows\\Media\\chimes.wav", "chord": "C:\\Windows\\Media\\chord.wav",
+  "ding": "C:\\Windows\\Media\\ding.wav", "notify": "C:\\Windows\\Media\\notify.wav",
+  "ringin": "C:\\Windows\\Media\\ringin.wav", "Windows Background": "C:\\Windows\\Media\\Windows Background.wav",
+};
+
+function playLocalSound(soundName: string, defaultMac: string, defaultWin: string) {
+  if (IS_WIN) {
+    const soundPath = WIN_SOUNDS[soundName] || defaultWin;
+    const ps = `$s='${soundPath}'; if(Test-Path $s){(New-Object Media.SoundPlayer $s).PlaySync()}else{[console]::Beep(800,300)}`;
+    exec(`powershell -NoProfile -NonInteractive -EncodedCommand ${Buffer.from(ps, "utf16le").toString("base64")}`, { timeout: 5000 });
+  } else {
+    const soundPath = MACOS_SOUNDS[soundName] || defaultMac;
+    exec(`afplay "${soundPath}"`);
+  }
+}
+
+function showLocalNotification(message: string) {
+  if (IS_WIN) {
+    const safeMsg = message.replace(/'/g, "''");
+    const ps = `Add-Type -AssemblyName System.Windows.Forms; $n=New-Object System.Windows.Forms.NotifyIcon; $n.Icon=[System.Drawing.SystemIcons]::Information; $n.Visible=$true; $n.ShowBalloonTip(3000,'Claude Notifier','${safeMsg}',[System.Windows.Forms.ToolTipIcon]::None); Start-Sleep -m 500; $n.Dispose()`;
+    exec(`powershell -NoProfile -NonInteractive -EncodedCommand ${Buffer.from(ps, "utf16le").toString("base64")}`, { timeout: 5000 });
+  } else {
+    exec(`osascript -e 'display notification "${message}" with title "Claude Notifier"'`);
+  }
+}
 
 function hookCmd(hookPath: string): string {
   if (IS_WIN) {
@@ -27,6 +66,7 @@ const ALL_HOOK_TYPES = ["Stop", "PermissionRequest", "PreToolUse", "Notification
 let statusBarItem: vscode.StatusBarItem;
 let watcher: fs.FSWatcher | null = null;
 let soundEnabled = true;
+let doneDebounceTimer: ReturnType<typeof setTimeout> | null = null;
 
 function playRemoteSound() {
   // In remote sessions, webview audio is blocked by Electron's autoplay policy.
@@ -44,6 +84,11 @@ function playRemoteSound() {
 export function activate(context: vscode.ExtensionContext) {
   setupHooks(context);
   syncConfig();
+
+  // Signal to hook scripts that the extension is running and will handle
+  // "done" sound/notification with debounce. Without this flag, hooks play
+  // sounds directly as a fallback for terminal-only users.
+  try { fs.writeFileSync(ACTIVE_FLAG, String(process.pid)); } catch {}
 
   soundEnabled = !fs.existsSync(MUTE_FLAG);
 
@@ -119,13 +164,20 @@ function syncConfig() {
   } catch {}
 }
 
-function getEventLevel(eventKey: string): string {
+function getEventConfig(eventKey: string): { level: string; sound: string } {
   try {
     const config = JSON.parse(fs.readFileSync(CONFIG_FILE, "utf-8"));
-    return config[eventKey]?.level ?? "sound+popup";
+    return {
+      level: config[eventKey]?.level ?? "sound+popup",
+      sound: config[eventKey]?.sound ?? "",
+    };
   } catch {
-    return "sound+popup";
+    return { level: "sound+popup", sound: "" };
   }
+}
+
+function getEventLevel(eventKey: string): string {
+  return getEventConfig(eventKey).level;
 }
 
 function handleSignal() {
@@ -137,9 +189,32 @@ function handleSignal() {
   }
 
   const reason = content.split(" ")[0];
-  // When running on a remote host the extension process is on the server and
-  // cannot play audio. VS Code webviews always render in the local renderer, so
-  // we synthesize a tone there instead.
+
+  if (reason === "done") {
+    // Debounce "done" signals — Claude fires Stop hooks between subtasks.
+    // Only notify after 3 seconds of silence (no new signals).
+    if (doneDebounceTimer) clearTimeout(doneDebounceTimer);
+    doneDebounceTimer = setTimeout(() => {
+      doneDebounceTimer = null;
+      showNotification("done");
+    }, 3000);
+  } else {
+    // "question" and "input" signals are immediate — user action is needed.
+    // Cancel any pending "done" notification (the stop after a question is expected).
+    if (doneDebounceTimer) {
+      clearTimeout(doneDebounceTimer);
+      doneDebounceTimer = null;
+    }
+    if (reason === "input" || reason === "question") {
+      showNotification(reason);
+    }
+  }
+}
+
+function showNotification(reason: string) {
+  // Architecture note: "question" and "input" local sounds are played by their
+  // respective hook scripts (PreToolUse / PermissionRequest) — not the extension.
+  // Only "done" local sounds are played here, because the extension debounces them.
   const isRemote = !!vscode.env.remoteName;
 
   if (reason === "input") {
@@ -160,11 +235,19 @@ function handleSignal() {
     }
   } else if (reason === "done") {
     const level = getEventLevel("taskCompleted");
-    if (isRemote && (level === "sound+popup" || level === "sound")) {
-      playRemoteSound();
+    if (level === "sound+popup" || level === "sound") {
+      if (isRemote) {
+        playRemoteSound();
+      } else {
+        const cfg = getEventConfig("taskCompleted");
+        playLocalSound(cfg.sound, "/System/Library/Sounds/Hero.aiff", "C:\\Windows\\Media\\tada.wav");
+      }
     }
     if (level === "sound+popup" || level === "popup") {
       vscode.window.showInformationMessage("Claude has finished the task.");
+      if (!isRemote) {
+        showLocalNotification("Claude has finished the task.");
+      }
     }
   }
 }
@@ -245,7 +328,7 @@ function setupHooks(context: vscode.ExtensionContext) {
 }
 
 function teardownHooks() {
-  for (const file of [STOP_HOOK, PERMISSION_HOOK, QUESTION_HOOK, SIGNAL_FILE, MUTE_FLAG, CONFIG_FILE]) {
+  for (const file of [STOP_HOOK, PERMISSION_HOOK, QUESTION_HOOK, SIGNAL_FILE, MUTE_FLAG, CONFIG_FILE, ACTIVE_FLAG]) {
     try { fs.unlinkSync(file); } catch {}
   }
   // Clean up legacy and cross-platform hook files
@@ -290,5 +373,6 @@ export function deactivate() {
     watcher.close();
     watcher = null;
   }
+  try { fs.unlinkSync(ACTIVE_FLAG); } catch {}
   teardownHooks();
 }


### PR DESCRIPTION
Fixes #9, #8

## Summary

Addresses two coordination bugs in the extension↔hook active-flag protocol

1. **Stale flag on crash** — a single `claude-notifier-active` file was written on `activate()` and removed on `deactivate()`. If the extension host crashed or was force-killed, the flag lingered and stop hooks silently deferred forever, leaving terminal users with no notifications until the extension ran again.
2. **Multi-window breakage** — with two VSCode windows open, the second `activate()` overwrote the flag, and whichever window deactivated first deleted it *and* ran `teardownHooks()`, pulling hook scripts / `settings.json` entries out from under the surviving window.

## Approach

Replace the single flag file with a directory `~/.claude/hooks/claude-notifier-active.d/` containing one marker file per live extension instance, named by PID.

- **Extension** (`src/extension.ts`): on activate, creates the dir, prunes stale PID files (via `process.kill(pid, 0)`), and writes its own marker. On deactivate, removes only its own marker and calls `teardownHooks()` *only* when no other live instance remains.
- **Hooks** (`claude-notifier-on-stop.js` / `.ps1`): `extensionIsActive()` scans the directory and verifies at least one marker corresponds to a live process (`process.kill(pid, 0)` / `Get-Process -Id`) before deferring. Stale markers are ignored, so the terminal fallback still fires.

## Test plan

- [x] Single window: install extension → run Claude task → extension notification fires, hook defers (no double sound).
- [x] Crash recovery: kill VSCode extension host → run Claude task in terminal → stop hook plays sound directly (stale PID ignored).
- [x] Multi-window: open two VSCode windows with the extension → close one → verify hooks still fire in the remaining window (`settings.json` entries and hook scripts intact).
- [x] Close last window → verify `teardownHooks()` runs and `claude-notifier-active.d/` is removed.
- [ ] Windows: repeat single-window and crash-recovery cases with the `.ps1` stop hook.
