### PR TITLE
feat: focus the Claude Code session tab when notification is clicked

### DIFF
--- a/hook/claude-notifier-on-stop.js
+++ b/hook/claude-notifier-on-stop.js
@@ -14,6 +14,26 @@ const MUTE_FLAG = path.join(HOOKS_DIR, "claude-notifier-muted");
 const SIGNAL_FILE = path.join(HOOKS_DIR, "claude-signal");
 const ACTIVE_DIR = path.join(HOOKS_DIR, "claude-notifier-active.d");
 
+// Walk the parent PID chain so the extension can match this hook's invocation
+// to a specific vscode.window.Terminal (whose processId is the shell pid —
+// one of our ancestors). macOS/Linux only; Windows skips and gets no per-tab
+// focus (just window focus).
+function getAncestorPids() {
+  if (process.platform === "win32") return [];
+  const chain = [];
+  let pid = process.ppid;
+  while (pid && pid > 1 && chain.length < 20) {
+    chain.push(pid);
+    try {
+      const out = require("child_process").execFileSync("/bin/ps", ["-o", "ppid=", "-p", String(pid)], { encoding: "utf-8" }).trim();
+      const next = parseInt(out, 10);
+      if (!next || Number.isNaN(next) || next === pid) break;
+      pid = next;
+    } catch { break; }
+  }
+  return chain;
+}
+
 function findTerminalNotifier() {
   if (process.platform !== "darwin") return null;
   for (const c of ["/opt/homebrew/bin/terminal-notifier", "/usr/local/bin/terminal-notifier"]) {
@@ -121,9 +141,15 @@ process.stdin.on("end", () => {
   const cwd = (input && input.cwd) || process.cwd() || "";
 
   // Write signal for the VSCode extension (which debounces "done" signals
-  // and routes them to the matching window via cwd).
+  // and routes them to the matching window via cwd). Format:
+  //   done <ts> <ancestor_pids_csv|-> <session_id|-> <cwd>
+  // ancestor pids let the extension identify which integrated terminal fired
+  // this hook; session_id lets it focus the specific Claude Code editor tab.
   try {
-    fs.writeFileSync(SIGNAL_FILE, `done ${Date.now()} ${cwd}`);
+    const pids = getAncestorPids();
+    const pidField = pids.length > 0 ? pids.join(",") : "-";
+    const sid = (input && input.session_id) ? String(input.session_id).replace(/\s+/g, "") : "-";
+    fs.writeFileSync(SIGNAL_FILE, `done ${Date.now()} ${pidField} ${sid} ${cwd}`);
   } catch {}
 
   // If a VSCode window owns this cwd, the extension handles sound/notification

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -22,6 +22,10 @@ const ACTIVE_DIR = path.join(HOOKS_DIR, "claude-notifier-active.d");
 const OWN_PID_FILE = path.join(ACTIVE_DIR, String(process.pid));
 const CONFIG_FILE = path.join(HOOKS_DIR, "claude-notifier-config.json");
 const SETTINGS_FILE = path.join(CLAUDE_DIR, "settings.json");
+// Per-window focus channel: terminal-notifier's click action writes
+// "<ts> <cwd>" here, and the extension whose workspace matches the cwd
+// focuses the terminal that fired the most recent Stop signal.
+const FOCUS_SIGNAL_FILE = path.join(HOOKS_DIR, "claude-notifier-focus-signal");
 
 const MACOS_SOUNDS: Record<string, string> = {
   Basso: "/System/Library/Sounds/Basso.aiff", Blow: "/System/Library/Sounds/Blow.aiff",
@@ -85,9 +89,16 @@ function showLocalNotification(message: string) {
     exec(`powershell -NoProfile -NonInteractive -EncodedCommand ${Buffer.from(ps, "utf16le").toString("base64")}`, { timeout: 5000 });
   } else if (IS_MAC && terminalNotifierPath) {
     const folder = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath ?? "";
-    const executeCmd = codeCliPath && folder
+    // Write a focus-signal first (so the right window's extension can focus
+    // its matched terminal), then activate VS Code. Both effects are
+    // independent; the `code` activation brings the window forward and the
+    // signal fs.watch fires `terminal.show()` inside that window.
+    const activateCmd = codeCliPath && folder
       ? `${shellQuote(codeCliPath)} ${shellQuote(folder)}`
       : `osascript -e 'tell application "Visual Studio Code" to activate'`;
+    const focusPayload = `${Date.now()} ${folder}`;
+    const focusCmd = `/bin/echo ${shellQuote(focusPayload)} > ${shellQuote(FOCUS_SIGNAL_FILE)}`;
+    const executeCmd = folder ? `${focusCmd} && ${activateCmd}` : activateCmd;
     const args = [
       "-title", "Claude Notifier",
       "-message", message,
@@ -115,8 +126,15 @@ const ALL_HOOK_TYPES = ["Stop", "PermissionRequest", "PreToolUse", "Notification
 
 let statusBarItem: vscode.StatusBarItem;
 let watcher: fs.FSWatcher | null = null;
+let focusWatcher: fs.FSWatcher | null = null;
 let soundEnabled = true;
 let doneDebounceTimer: ReturnType<typeof setTimeout> | null = null;
+// Terminal that fired the most recent "done" signal in this window. Used by
+// the focus-signal handler to route click-to-tab focus.
+let lastDoneTerminal: vscode.Terminal | null = null;
+// Session id of the most recent Stop signal received in this window. Used as
+// the focus target for the Claude Code extension's panel.
+let lastDoneSessionId: string | null = null;
 
 function isPidAlive(pid: number): boolean {
   try { process.kill(pid, 0); return true; } catch { return false; }
@@ -148,6 +166,39 @@ function cleanStalePidFiles() {
       }
     }
   } catch {}
+}
+
+async function findTerminalByAncestors(ancestorPids: number[]): Promise<vscode.Terminal | null> {
+  for (const term of vscode.window.terminals) {
+    try {
+      const pid = await term.processId;
+      if (pid && ancestorPids.includes(pid)) return term;
+    } catch {}
+  }
+  return null;
+}
+
+async function handleFocusSignal() {
+  let content = "";
+  try { content = fs.readFileSync(FOCUS_SIGNAL_FILE, "utf-8").trim(); } catch { return; }
+  // Format: "<ts> <cwd...>"
+  const firstSpace = content.indexOf(" ");
+  const cwd = firstSpace >= 0 ? content.slice(firstSpace + 1) : "";
+  if (!cwd) return;
+  const folders = getOwnWorkspaceFolders();
+  if (folders.length > 0 && !folders.some((f) => cwdMatchesFolder(cwd, f))) return;
+  if (lastDoneTerminal) {
+    try { lastDoneTerminal.show(); return; } catch {}
+  }
+  // Focus the Claude Code editor tab for the session that just finished.
+  // claude-vscode.editor.open(sessionId) reveals the existing panel if the
+  // session id is open; we only call it when we have a session id to avoid
+  // creating a new empty panel.
+  if (lastDoneSessionId) {
+    try {
+      await vscode.commands.executeCommand("claude-vscode.editor.open", lastDoneSessionId);
+    } catch {}
+  }
 }
 
 function playRemoteSound() {
@@ -189,6 +240,9 @@ export function activate(context: vscode.ExtensionContext) {
 
   if (!fs.existsSync(SIGNAL_FILE)) {
     fs.writeFileSync(SIGNAL_FILE, "");
+  }
+  if (!fs.existsSync(FOCUS_SIGNAL_FILE)) {
+    fs.writeFileSync(FOCUS_SIGNAL_FILE, "");
   }
 
   statusBarItem = vscode.window.createStatusBarItem(
@@ -236,6 +290,13 @@ export function activate(context: vscode.ExtensionContext) {
     }
   });
   context.subscriptions.push({ dispose: () => watcher?.close() });
+
+  focusWatcher = fs.watch(FOCUS_SIGNAL_FILE, (eventType) => {
+    if (eventType === "change") {
+      handleFocusSignal();
+    }
+  });
+  context.subscriptions.push({ dispose: () => focusWatcher?.close() });
 }
 
 function updateStatusBar() {
@@ -289,11 +350,20 @@ function handleSignal() {
     return;
   }
 
-  // Signal format: "<reason> <timestamp> <cwd...>" — cwd may contain spaces.
-  const firstSpace = content.indexOf(" ");
-  const secondSpace = firstSpace >= 0 ? content.indexOf(" ", firstSpace + 1) : -1;
-  const reason = firstSpace < 0 ? content : content.slice(0, firstSpace);
-  const cwd = secondSpace >= 0 ? content.slice(secondSpace + 1) : "";
+  // Signal formats (Stop hook is v3; question/input still write v1):
+  //   v3: "done <ts> <pids_csv|-> <session_id|-> <cwd...>"
+  //   v1: "<reason> <ts> <cwd...>" or "<reason> <ts>"
+  // Detect v3 by checking whether parts[2] is digits-CSV or "-" (PID field).
+  const parts = content.split(" ");
+  const reason = parts[0] ?? "";
+  const maybePids = parts[2];
+  const hasPidsField = maybePids === "-" || /^[0-9]+(,[0-9]+)*$/.test(maybePids ?? "");
+  const ancestorPids = hasPidsField && maybePids !== "-"
+    ? maybePids!.split(",").map((s) => parseInt(s, 10)).filter((n) => Number.isFinite(n))
+    : [];
+  const sessionId = hasPidsField && parts[3] && parts[3] !== "-" ? parts[3] : null;
+  const cwdStart = hasPidsField ? 4 : 2;
+  const cwd = parts.slice(cwdStart).join(" ");
 
   // Each window only handles signals fired from inside its own workspace.
   // Signals without a cwd (older hook scripts) fall through to all windows
@@ -302,6 +372,15 @@ function handleSignal() {
     const folders = getOwnWorkspaceFolders();
     if (folders.length > 0 && !folders.some((f) => cwdMatchesFolder(cwd, f))) {
       return;
+    }
+  }
+
+  if (reason === "done") {
+    lastDoneSessionId = sessionId;
+    if (ancestorPids.length > 0) {
+      findTerminalByAncestors(ancestorPids).then((t) => { lastDoneTerminal = t; });
+    } else {
+      lastDoneTerminal = null;
     }
   }
 
@@ -479,7 +558,7 @@ function setupHooks(context: vscode.ExtensionContext) {
 }
 
 function teardownHooks() {
-  for (const file of [STOP_HOOK, PERMISSION_HOOK, QUESTION_HOOK, SIGNAL_FILE, MUTE_FLAG, CONFIG_FILE]) {
+  for (const file of [STOP_HOOK, PERMISSION_HOOK, QUESTION_HOOK, SIGNAL_FILE, FOCUS_SIGNAL_FILE, MUTE_FLAG, CONFIG_FILE]) {
     try { fs.unlinkSync(file); } catch {}
   }
   try { fs.rmdirSync(ACTIVE_DIR); } catch {}
@@ -527,6 +606,10 @@ export function deactivate() {
   if (watcher) {
     watcher.close();
     watcher = null;
+  }
+  if (focusWatcher) {
+    focusWatcher.close();
+    focusWatcher = null;
   }
   // Drop only this window's PID marker. Leave hook scripts and settings.json
   // entries in place so Claude Code outside VS Code (terminal, desktop app)


### PR DESCRIPTION
> Note: the README asks contributors to open an issue first. Happy to convert this to an issue if you'd prefer to discuss before reviewing code — I went straight to a PR because the change is self-contained and easy to revert. Feel free to close if you'd rather start with a discussion.

## Summary

- Stop-hook notifications: clicking now focuses the **specific Claude Code editor tab** (or integrated terminal) the Stop hook fired from — not just the workspace window.
- Adds a parent-PID chain + `session_id` to the `claude-signal` payload so the extension can identify both terminal-based and extension-panel-based Claude sessions.
- terminal-notifier's click action now writes a separate `claude-notifier-focus-signal` file; the matching window's extension reveals the right target (`terminal.show()` for an integrated terminal, otherwise `claude-vscode.editor.open(sessionId)` to reveal the existing session panel).
- Backwards-compatible with the v1 signal format used by the question / permission hooks.

## Why

Click currently brings the right window forward (good), but the user still has to hunt for the Claude session they were working in. With several sessions open as editor tabs (which seems to be the dominant usage of the Anthropic Claude Code extension), that's a real friction point — especially when you fire off a long task and walk away.

## How it works

**Stop hook (`hook/claude-notifier-on-stop.js`)** — captures the parent PID chain by walking `/bin/ps -o ppid=` and reads `session_id` from the hook input JSON. New signal format:

```
done <ts> <ancestor_pids_csv|-> <session_id|-> <cwd>
```

The PID-detection path no-ops on Windows; macOS/Linux only.

**Extension (`src/extension.ts`)** —
1. Parses the new format (and still parses old `done <ts> <cwd>` for compat with the question/input hooks).
2. On a `done` signal, finds any `vscode.window.terminals` entry whose `processId` appears in the ancestor chain and stores it as `lastDoneTerminal`. Also stores `lastDoneSessionId`.
3. terminal-notifier's `-execute` is now `echo <ts> <cwd> > FOCUS_SIGNAL_FILE && code <folder>` — the focus-signal write triggers a second `fs.watch` in the extension.
4. The focus-signal handler filters by cwd (so only the matching window acts) and either calls `lastDoneTerminal.show()` or `vscode.commands.executeCommand("claude-vscode.editor.open", lastDoneSessionId)`. The `claude-vscode.editor.open` command in the Anthropic extension calls `createPanel(sessionId, …)` which reveals the existing session panel if one is open for that id (otherwise no-ops, since we only call it when we have a session id).

## Scope notes

- Question / permission hook flows are untouched. Focus-on-click is currently Stop-only — same scope as the existing window-focus behavior on click.
- Falls through silently if neither a terminal match nor a session id resolves (e.g. Claude run from an external terminal outside any VS Code workspace).
- Did not touch CHANGELOG.md — happy to add an entry if you'd prefer, or leave it for the release commit.

## Test plan

Tested on macOS 26 (Tahoe) with `terminal-notifier 2.0.0` and the Anthropic Claude Code extension v2.1.142, running Claude as editor tabs:

- [x] Stop hook fires → notification shows
- [x] Click notification → correct VS Code window comes forward
- [x] Click notification → the specific Claude Code editor tab for the firing session is revealed (verified across two parallel sessions in different tabs)
- [x] Signal-file format change does not break the question / permission notifications (they still use the v1 format, which the new parser handles)
- [x] Compiles clean (`tsc -p ./`)
- [ ] Not retested on Windows / WSL / Linux — PID-chain walk is gated to non-Windows, and the click-focus path is macOS-only (terminal-notifier), so this should be a no-op on those platforms. Sanity check from a maintainer on those platforms would be welcome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)