### PR TITLE
rebuild p2: hook _lib/ extraction + safer shell escaping

### DIFF
--- a/hook/_lib.ps1
+++ b/hook/_lib.ps1
@@ -1,0 +1,100 @@
+# Claude Notifier — shared PowerShell hook library.
+# Dot-sourced by each hook: `. (Join-Path $PSScriptRoot '_lib.ps1')`.
+$ErrorActionPreference = 'SilentlyContinue'
+
+$LibHooksDir   = $PSScriptRoot
+$LibMuteFlag   = Join-Path $LibHooksDir 'claude-notifier-muted'
+$LibSignalFile = Join-Path $LibHooksDir 'claude-signal'
+$LibConfigFile = Join-Path $LibHooksDir 'claude-notifier-config.json'
+$LibActiveDir  = Join-Path $LibHooksDir 'claude-notifier-active.d'
+
+$LibWinSounds = @{
+    'Windows Notify'     = 'C:\Windows\Media\Windows Notify.wav'
+    'tada'               = 'C:\Windows\Media\tada.wav'
+    'chimes'             = 'C:\Windows\Media\chimes.wav'
+    'chord'              = 'C:\Windows\Media\chord.wav'
+    'ding'               = 'C:\Windows\Media\ding.wav'
+    'notify'             = 'C:\Windows\Media\notify.wav'
+    'ringin'             = 'C:\Windows\Media\ringin.wav'
+    'Windows Background' = 'C:\Windows\Media\Windows Background.wav'
+}
+
+# Resolve a sound preset name to a Windows .wav path. Falls back to $Default
+# when the name is missing or unknown.
+function Resolve-NotifierSound([string]$Name, [string]$Default) {
+    if ($Name -and $LibWinSounds.ContainsKey($Name)) { return $LibWinSounds[$Name] }
+    return $Default
+}
+
+# Read claude-notifier-config.json. Returns $null on any error.
+function Read-NotifierConfig() {
+    try { return (Get-Content $LibConfigFile -Raw) | ConvertFrom-Json } catch { return $null }
+}
+
+# Returns $true when the global mute flag is set.
+function Test-NotifierMuted() {
+    return (Test-Path $LibMuteFlag)
+}
+
+# Play a sound file synchronously. Beeps on missing file. Silently swallows
+# errors — sound failure should never break a hook.
+function Invoke-NotifierSound([string]$Path) {
+    try {
+        if (Test-Path $Path) {
+            (New-Object Media.SoundPlayer $Path).PlaySync()
+        } else {
+            [console]::Beep(800, 300)
+        }
+    } catch {}
+}
+
+# Show a Windows balloon notification (title is always "Claude Notifier").
+function Show-NotifierNotification([string]$Message) {
+    try {
+        Add-Type -AssemblyName System.Windows.Forms
+        $n = New-Object System.Windows.Forms.NotifyIcon
+        $n.Icon = [System.Drawing.SystemIcons]::Information
+        $n.Visible = $true
+        $n.ShowBalloonTip(3000, 'Claude Notifier', $Message, [System.Windows.Forms.ToolTipIcon]::None)
+        Start-Sleep -Milliseconds 500
+        $n.Dispose()
+    } catch {}
+}
+
+# Write a signal for the extension. Format: "<reason> <unix-secs> [cwd]".
+# Matches the existing PS1 timestamp format (seconds, not ms).
+function Write-NotifierSignal([string]$Reason, [string]$Cwd) {
+    try {
+        $ts = (Get-Date -UFormat %s)
+        $payload = if ($Cwd) { "$Reason $ts $Cwd" } else { "$Reason $ts" }
+        Set-Content -Path $LibSignalFile -Value $payload -NoNewline
+    } catch {}
+}
+
+# True when $Cwd is inside $Folder (handles trailing separator equivalence).
+function Test-CwdInsideFolder([string]$Cwd, [string]$Folder) {
+    if (-not $Cwd -or -not $Folder) { return $false }
+    if ($Cwd -eq $Folder) { return $true }
+    $sep = [IO.Path]::DirectorySeparatorChar
+    if (-not $Folder.EndsWith($sep)) { $Folder = $Folder + $sep }
+    return $Cwd.StartsWith($Folder)
+}
+
+# True if any live extension window owns this cwd. Backwards-compat: empty
+# marker file means a pre-cwd-routing extension is running — defer to it.
+function Test-ExtensionOwnsCwd([string]$Cwd) {
+    if (-not (Test-Path $LibActiveDir)) { return $false }
+    foreach ($f in Get-ChildItem -Path $LibActiveDir -File -ErrorAction SilentlyContinue) {
+        $pidVal = 0
+        if (-not [int]::TryParse($f.Name, [ref]$pidVal)) { continue }
+        if (-not (Get-Process -Id $pidVal -ErrorAction SilentlyContinue)) { continue }
+        $folders = ""
+        try { $folders = [IO.File]::ReadAllText($f.FullName) } catch {}
+        if (-not $folders.Trim()) { return $true }
+        foreach ($line in $folders -split "`n") {
+            $folder = $line.Trim()
+            if ($folder -and (Test-CwdInsideFolder $Cwd $folder)) { return $true }
+        }
+    }
+    return $false
+}

--- a/hook/_lib/active.js
+++ b/hook/_lib/active.js
@@ -1,0 +1,37 @@
+const fs = require("fs");
+const path = require("path");
+const { ACTIVE_DIR } = require("./paths");
+
+function cwdInsideFolder(cwd, folder) {
+  if (!cwd || !folder) return false;
+  if (cwd === folder) return true;
+  const sep = path.sep;
+  return cwd.startsWith(folder.endsWith(sep) ? folder : folder + sep);
+}
+
+/**
+ * Returns true if any live extension owns this cwd — i.e. some VS Code window
+ * has a workspace folder that contains the firing cwd. When false, the hook
+ * falls through to terminal-fallback notifications.
+ *
+ * Backwards-compat: an empty marker file means a pre-cwd-routing extension is
+ * running; defer to it for any signal until its window reloads.
+ */
+function extensionOwnsCwd(cwd) {
+  let entries;
+  try { entries = fs.readdirSync(ACTIVE_DIR); } catch { return false; }
+  for (const name of entries) {
+    const pid = parseInt(name, 10);
+    if (!Number.isFinite(pid)) continue;
+    try { process.kill(pid, 0); } catch { continue; }
+    let folders = "";
+    try { folders = fs.readFileSync(path.join(ACTIVE_DIR, name), "utf-8"); } catch {}
+    if (!folders.trim()) return true;
+    for (const folder of folders.split("\n").map((s) => s.trim()).filter(Boolean)) {
+      if (cwdInsideFolder(cwd, folder)) return true;
+    }
+  }
+  return false;
+}
+
+module.exports = { extensionOwnsCwd, cwdInsideFolder };

--- a/hook/_lib/config.js
+++ b/hook/_lib/config.js
@@ -1,0 +1,13 @@
+const fs = require("fs");
+const { CONFIG_FILE, MUTE_FLAG } = require("./paths");
+
+function readConfig() {
+  try { return JSON.parse(fs.readFileSync(CONFIG_FILE, "utf-8")); }
+  catch { return null; }
+}
+
+function isMuted() {
+  return fs.existsSync(MUTE_FLAG);
+}
+
+module.exports = { readConfig, isMuted };

--- a/hook/_lib/notify.js
+++ b/hook/_lib/notify.js
@@ -1,0 +1,63 @@
+const fs = require("fs");
+const { execSync, execFileSync } = require("child_process");
+const { USE_WIN, IS_LINUX, IS_MAC, PS_BIN } = require("./platform");
+
+const TITLE = "Claude Notifier";
+
+// PowerShell single-quoted strings escape ' as ''. Anything else is literal.
+function psSingleQuoteEscape(s) {
+  return String(s).replace(/'/g, "''");
+}
+
+// AppleScript double-quoted string literals: escape \ and ".
+function appleScriptEscape(s) {
+  return String(s).replace(/[\\"]/g, "\\$&");
+}
+
+function findTerminalNotifier() {
+  if (!IS_MAC) return null;
+  for (const c of ["/opt/homebrew/bin/terminal-notifier", "/usr/local/bin/terminal-notifier"]) {
+    try { fs.accessSync(c, fs.constants.X_OK); return c; } catch {}
+  }
+  try {
+    const out = execFileSync("/usr/bin/which", ["terminal-notifier"], { encoding: "utf-8" }).trim();
+    if (out) return out;
+  } catch {}
+  return null;
+}
+
+/**
+ * Show an OS notification. Title is always "Claude Notifier".
+ *
+ * On macOS: when opts.preferTerminalNotifier is true and terminal-notifier is
+ * installed, use it (gives clickable notifications that focus VS Code). Else
+ * falls back to osascript. Non-stop hooks set this to false because the
+ * popup is short-lived and clickability matters less when the user is active.
+ */
+function showNotification(message, opts = {}) {
+  const preferTn = !!opts.preferTerminalNotifier;
+  try {
+    if (USE_WIN) {
+      const safeMsg = psSingleQuoteEscape(message);
+      const safeTitle = psSingleQuoteEscape(TITLE);
+      const ps = `Add-Type -AssemblyName System.Windows.Forms; $n=New-Object System.Windows.Forms.NotifyIcon; $n.Icon=[System.Drawing.SystemIcons]::Information; $n.Visible=$true; $n.ShowBalloonTip(3000,'${safeTitle}','${safeMsg}',[System.Windows.Forms.ToolTipIcon]::None); Start-Sleep -m 500; $n.Dispose()`;
+      execSync(`${PS_BIN} -NoProfile -NonInteractive -EncodedCommand ${Buffer.from(ps, "utf16le").toString("base64")}`, { stdio: "ignore", timeout: 5000 });
+    } else if (IS_LINUX) {
+      // execFileSync bypasses the shell — no shell-escaping concerns for $ or `.
+      execFileSync("notify-send", ["--app-name=Claude Code", TITLE, String(message)], { stdio: "ignore", timeout: 5000 });
+    } else if (IS_MAC) {
+      if (preferTn) {
+        const tn = findTerminalNotifier();
+        if (tn) {
+          execFileSync(tn, ["-title", TITLE, "-message", String(message)], { stdio: "ignore" });
+          return;
+        }
+      }
+      // execFileSync bypasses the shell; AppleScript still needs its own \ and " escaping.
+      const escaped = appleScriptEscape(message);
+      execFileSync("osascript", ["-e", `display notification "${escaped}" with title "${TITLE}"`], { stdio: "ignore" });
+    }
+  } catch {}
+}
+
+module.exports = { showNotification, findTerminalNotifier, TITLE };

--- a/hook/_lib/paths.js
+++ b/hook/_lib/paths.js
@@ -1,0 +1,9 @@
+const path = require("path");
+
+const HOOKS_DIR = path.join(process.env.HOME || process.env.USERPROFILE || "~", ".claude", "hooks");
+const MUTE_FLAG = path.join(HOOKS_DIR, "claude-notifier-muted");
+const SIGNAL_FILE = path.join(HOOKS_DIR, "claude-signal");
+const CONFIG_FILE = path.join(HOOKS_DIR, "claude-notifier-config.json");
+const ACTIVE_DIR = path.join(HOOKS_DIR, "claude-notifier-active.d");
+
+module.exports = { HOOKS_DIR, MUTE_FLAG, SIGNAL_FILE, CONFIG_FILE, ACTIVE_DIR };

--- a/hook/_lib/platform.js
+++ b/hook/_lib/platform.js
@@ -1,0 +1,12 @@
+const fs = require("fs");
+
+const IS_WIN = process.platform === "win32";
+const IS_WSL = !IS_WIN && process.platform === "linux" && (() => {
+  try { return fs.readFileSync("/proc/version", "utf-8").toLowerCase().includes("microsoft"); } catch { return false; }
+})();
+const USE_WIN = IS_WIN || IS_WSL;
+const PS_BIN = IS_WSL ? "powershell.exe" : "powershell";
+const IS_LINUX = !IS_WIN && !IS_WSL && process.platform === "linux";
+const IS_MAC = process.platform === "darwin";
+
+module.exports = { IS_WIN, IS_WSL, USE_WIN, PS_BIN, IS_LINUX, IS_MAC };

--- a/hook/_lib/play.js
+++ b/hook/_lib/play.js
@@ -1,0 +1,22 @@
+const { execSync } = require("child_process");
+const { USE_WIN, IS_LINUX, PS_BIN } = require("./platform");
+
+/**
+ * Play a sound file using the platform-native player. Silently swallows errors
+ * — sound failure should never break a hook.
+ */
+function playSound(soundPath) {
+  try {
+    if (USE_WIN) {
+      const ps = `$s='${soundPath}'; if(Test-Path $s){(New-Object Media.SoundPlayer $s).PlaySync()}else{[console]::Beep(800,300)}`;
+      execSync(`${PS_BIN} -NoProfile -NonInteractive -EncodedCommand ${Buffer.from(ps, "utf16le").toString("base64")}`, { stdio: "ignore", timeout: 5000 });
+    } else if (IS_LINUX) {
+      // paplay (PulseAudio/PipeWire) preferred; aplay (ALSA) as fallback.
+      execSync(`paplay "${soundPath}" 2>/dev/null || aplay "${soundPath}" 2>/dev/null`, { stdio: "ignore", timeout: 5000 });
+    } else {
+      execSync(`afplay "${soundPath}"`, { stdio: "ignore" });
+    }
+  } catch {}
+}
+
+module.exports = { playSound };

--- a/hook/_lib/signal.js
+++ b/hook/_lib/signal.js
@@ -1,0 +1,15 @@
+const fs = require("fs");
+const { SIGNAL_FILE } = require("./paths");
+
+/**
+ * Write a signal for the extension to consume. Format: "<reason> <ts> <cwd?>".
+ * cwd is optional — Stop includes it for per-window routing; others omit it.
+ */
+function writeSignal(reason, cwd) {
+  try {
+    const payload = cwd ? `${reason} ${Date.now()} ${cwd}` : `${reason} ${Date.now()}`;
+    fs.writeFileSync(SIGNAL_FILE, payload);
+  } catch {}
+}
+
+module.exports = { writeSignal };

--- a/hook/_lib/sounds.js
+++ b/hook/_lib/sounds.js
@@ -1,0 +1,51 @@
+const { USE_WIN, IS_LINUX } = require("./platform");
+
+const MACOS_SOUNDS = {
+  Basso: "/System/Library/Sounds/Basso.aiff", Blow: "/System/Library/Sounds/Blow.aiff",
+  Bottle: "/System/Library/Sounds/Bottle.aiff", Frog: "/System/Library/Sounds/Frog.aiff",
+  Funk: "/System/Library/Sounds/Funk.aiff", Glass: "/System/Library/Sounds/Glass.aiff",
+  Hero: "/System/Library/Sounds/Hero.aiff", Morse: "/System/Library/Sounds/Morse.aiff",
+  Ping: "/System/Library/Sounds/Ping.aiff", Pop: "/System/Library/Sounds/Pop.aiff",
+  Purr: "/System/Library/Sounds/Purr.aiff", Sosumi: "/System/Library/Sounds/Sosumi.aiff",
+  Submarine: "/System/Library/Sounds/Submarine.aiff", Tink: "/System/Library/Sounds/Tink.aiff",
+};
+
+const WIN_SOUNDS = {
+  "Windows Notify": "C:\\Windows\\Media\\Windows Notify.wav", "tada": "C:\\Windows\\Media\\tada.wav",
+  "chimes": "C:\\Windows\\Media\\chimes.wav", "chord": "C:\\Windows\\Media\\chord.wav",
+  "ding": "C:\\Windows\\Media\\ding.wav", "notify": "C:\\Windows\\Media\\notify.wav",
+  "ringin": "C:\\Windows\\Media\\ringin.wav", "Windows Background": "C:\\Windows\\Media\\Windows Background.wav",
+};
+
+const LINUX_SOUNDS_DIR = "/usr/share/sounds/freedesktop/stereo";
+const LINUX_SOUNDS = {
+  Basso:     `${LINUX_SOUNDS_DIR}/dialog-warning.oga`,
+  Blow:      `${LINUX_SOUNDS_DIR}/service-logout.oga`,
+  Bottle:    `${LINUX_SOUNDS_DIR}/bell.oga`,
+  Frog:      `${LINUX_SOUNDS_DIR}/message-new-instant.oga`,
+  Funk:      `${LINUX_SOUNDS_DIR}/message-new-instant.oga`,
+  Glass:     `${LINUX_SOUNDS_DIR}/bell.oga`,
+  Hero:      `${LINUX_SOUNDS_DIR}/complete.oga`,
+  Morse:     `${LINUX_SOUNDS_DIR}/message.oga`,
+  Ping:      `${LINUX_SOUNDS_DIR}/message.oga`,
+  Pop:       `${LINUX_SOUNDS_DIR}/dialog-information.oga`,
+  Purr:      `${LINUX_SOUNDS_DIR}/service-login.oga`,
+  Sosumi:    `${LINUX_SOUNDS_DIR}/dialog-warning.oga`,
+  Submarine: `${LINUX_SOUNDS_DIR}/alarm-clock-elapsed.oga`,
+  Tink:      `${LINUX_SOUNDS_DIR}/bell.oga`,
+};
+
+/**
+ * Resolve a sound preset name to an absolute file path for the current platform.
+ * Falls back to the platform-specific default when the name is missing or unknown.
+ */
+function resolveSound(name, defaultMac, defaultWin) {
+  if (USE_WIN) return WIN_SOUNDS[name] || defaultWin;
+  if (IS_LINUX) return LINUX_SOUNDS[name] || `${LINUX_SOUNDS_DIR}/complete.oga`;
+  return MACOS_SOUNDS[name] || defaultMac;
+}
+
+module.exports = {
+  MACOS_SOUNDS, WIN_SOUNDS, LINUX_SOUNDS, LINUX_SOUNDS_DIR,
+  resolveSound,
+};

--- a/hook/claude-notifier-on-notification.js
+++ b/hook/claude-notifier-on-notification.js
@@ -1,25 +1,13 @@
 #!/usr/bin/env node
-// Claude Notifier — Notification hook script
-// Plays the "needs input" sound when Claude needs permission.
-const fs = require("fs");
-const path = require("path");
-const { execSync } = require("child_process");
-
-const HOOKS_DIR = path.join(process.env.HOME || process.env.USERPROFILE || "~", ".claude", "hooks");
-const MUTE_FLAG = path.join(HOOKS_DIR, "claude-notifier-muted");
-const IS_WIN = process.platform === "win32";
-const IS_WSL = !IS_WIN && process.platform === "linux" && (() => {
-  try { return fs.readFileSync("/proc/version", "utf-8").toLowerCase().includes("microsoft"); } catch { return false; }
-})();
-const USE_WIN = IS_WIN || IS_WSL;
-const PS_BIN = IS_WSL ? "powershell.exe" : "powershell";
-const IS_LINUX = !IS_WIN && !IS_WSL && process.platform === "linux";
-
-const SOUND = USE_WIN
-  ? "C:\\Windows\\Media\\Windows Notify.wav"
-  : IS_LINUX
-  ? "/usr/share/sounds/freedesktop/stereo/bell.oga"
-  : "/System/Library/Sounds/Glass.aiff";
+// Claude Notifier — Notification hook (v2)
+// Plays the "needs input" sound when Claude posts a permission_prompt
+// notification. Uses fixed sound (not config-driven) — this hook fires
+// before the PermissionRequest hook can react.
+const { isMuted } = require("./_lib/config");
+const { resolveSound } = require("./_lib/sounds");
+const { playSound } = require("./_lib/play");
+const { showNotification } = require("./_lib/notify");
+const { writeSignal } = require("./_lib/signal");
 
 let raw = "";
 process.stdin.setEncoding("utf-8");
@@ -29,39 +17,17 @@ process.stdin.on("end", () => {
   try { input = JSON.parse(raw); } catch { process.exit(0); }
 
   if (input.notification_type !== "permission_prompt") process.exit(0);
-  if (fs.existsSync(MUTE_FLAG)) process.exit(0);
+  if (isMuted()) process.exit(0);
 
-  // Play sound
-  try {
-    if (USE_WIN) {
-      const ps = `$s='${SOUND}'; if(Test-Path $s){(New-Object Media.SoundPlayer $s).PlaySync()}else{[console]::Beep(800,300)}`;
-      execSync(`${PS_BIN} -NoProfile -NonInteractive -EncodedCommand ${Buffer.from(ps, "utf16le").toString("base64")}`, { stdio: "ignore", timeout: 5000 });
-    } else if (IS_LINUX) {
-      execSync(`paplay "${SOUND}" 2>/dev/null || aplay "${SOUND}" 2>/dev/null`, { stdio: "ignore", timeout: 5000 });
-    } else {
-      execSync(`afplay "${SOUND}"`, { stdio: "ignore" });
-    }
-  } catch {}
+  // Fixed sound mapping (Glass on macOS, Notify on Windows, freedesktop bell
+  // on Linux — resolveSound's table happens to map "Glass" to all three).
+  const sound = resolveSound("Glass", "/System/Library/Sounds/Glass.aiff", "C:\\Windows\\Media\\Windows Notify.wav");
+  playSound(sound);
 
-  // OS notification
-  try {
-    const message = input.message || "Claude needs your permission.";
-    if (USE_WIN) {
-      const safeMsg = message.replace(/'/g, "''");
-      const ps = `Add-Type -AssemblyName System.Windows.Forms; $n=New-Object System.Windows.Forms.NotifyIcon; $n.Icon=[System.Drawing.SystemIcons]::Information; $n.Visible=$true; $n.ShowBalloonTip(3000,'Claude Notifier','${safeMsg}',[System.Windows.Forms.ToolTipIcon]::None); Start-Sleep -m 500; $n.Dispose()`;
-      execSync(`${PS_BIN} -NoProfile -NonInteractive -EncodedCommand ${Buffer.from(ps, "utf16le").toString("base64")}`, { stdio: "ignore", timeout: 5000 });
-    } else if (IS_LINUX) {
-      const safeMsg = message.replace(/"/g, '\\"');
-      execSync(`notify-send "Claude Notifier" "${safeMsg}" 2>/dev/null`, { stdio: "ignore", timeout: 5000 });
-    } else {
-      execSync(`osascript -e 'display notification "${message}" with title "Claude Notifier"'`, { stdio: "ignore" });
-    }
-  } catch {}
+  const message = input.message || "Claude needs your permission.";
+  showNotification(message);
 
-  // Write signal for VSCode extension
-  try {
-    fs.writeFileSync(path.join(HOOKS_DIR, "claude-signal"), "input " + Date.now());
-  } catch {}
+  writeSignal("input");
 
   process.exit(0);
 });

--- a/hook/claude-notifier-on-notification.ps1
+++ b/hook/claude-notifier-on-notification.ps1
@@ -1,37 +1,20 @@
-# Claude Notifier - Notification hook (PowerShell)
-# Plays sound when Claude sends a notification.
+# Claude Notifier - Notification hook (PowerShell, v2)
+# Plays sound + shows notification on permission_prompt notifications.
+# Uses fixed sound (not config-driven).
 $ErrorActionPreference = 'SilentlyContinue'
-
-$hooksDir = $PSScriptRoot
-$muteFlag = Join-Path $hooksDir 'claude-notifier-muted'
+. (Join-Path $PSScriptRoot '_lib.ps1')
 
 $raw = [Console]::In.ReadToEnd()
 try { $data = $raw | ConvertFrom-Json } catch { exit 0 }
 
 if ($data.notification_type -ne 'permission_prompt') { exit 0 }
-if (Test-Path $muteFlag) { exit 0 }
+if (Test-NotifierMuted) { exit 0 }
 
-$sound = 'C:\Windows\Media\Windows Notify.wav'
+Invoke-NotifierSound -Path 'C:\Windows\Media\Windows Notify.wav'
 
-# Play sound
-try {
-    if (Test-Path $sound) { (New-Object Media.SoundPlayer $sound).PlaySync() }
-    else { [console]::Beep(800, 300) }
-} catch {}
+$message = if ($data.message) { $data.message } else { 'Claude needs your permission.' }
+Show-NotifierNotification -Message $message
 
-# OS notification
-try {
-    $message = if ($data.message) { $data.message } else { 'Claude needs your permission.' }
-    Add-Type -AssemblyName System.Windows.Forms
-    $n = New-Object System.Windows.Forms.NotifyIcon
-    $n.Icon = [System.Drawing.SystemIcons]::Information
-    $n.Visible = $true
-    $n.ShowBalloonTip(3000, 'Claude Notifier', $message, [System.Windows.Forms.ToolTipIcon]::None)
-    Start-Sleep -Milliseconds 500
-    $n.Dispose()
-} catch {}
+Write-NotifierSignal -Reason 'input'
 
-# Write signal for VSCode extension
-try {
-    Set-Content -Path (Join-Path $hooksDir 'claude-signal') -Value "input $(Get-Date -UFormat %s)" -NoNewline
-} catch {}
+exit 0

--- a/hook/claude-notifier-on-permission.js
+++ b/hook/claude-notifier-on-permission.js
@@ -1,63 +1,11 @@
 #!/usr/bin/env node
-// Claude Notifier — PermissionRequest hook script (v2)
-// Plays a sound when Claude needs permission to use a tool.
-const fs = require("fs");
-const path = require("path");
-const { execSync } = require("child_process");
-
-const HOOKS_DIR = path.join(process.env.HOME || process.env.USERPROFILE || "~", ".claude", "hooks");
-const MUTE_FLAG = path.join(HOOKS_DIR, "claude-notifier-muted");
-const IS_WIN = process.platform === "win32";
-const IS_WSL = !IS_WIN && process.platform === "linux" && (() => {
-  try { return fs.readFileSync("/proc/version", "utf-8").toLowerCase().includes("microsoft"); } catch { return false; }
-})();
-const USE_WIN = IS_WIN || IS_WSL;
-const PS_BIN = IS_WSL ? "powershell.exe" : "powershell";
-const IS_LINUX = !IS_WIN && !IS_WSL && process.platform === "linux";
-
-const MACOS_SOUNDS = {
-  Basso: "/System/Library/Sounds/Basso.aiff", Blow: "/System/Library/Sounds/Blow.aiff",
-  Bottle: "/System/Library/Sounds/Bottle.aiff", Frog: "/System/Library/Sounds/Frog.aiff",
-  Funk: "/System/Library/Sounds/Funk.aiff", Glass: "/System/Library/Sounds/Glass.aiff",
-  Hero: "/System/Library/Sounds/Hero.aiff", Morse: "/System/Library/Sounds/Morse.aiff",
-  Ping: "/System/Library/Sounds/Ping.aiff", Pop: "/System/Library/Sounds/Pop.aiff",
-  Purr: "/System/Library/Sounds/Purr.aiff", Sosumi: "/System/Library/Sounds/Sosumi.aiff",
-  Submarine: "/System/Library/Sounds/Submarine.aiff", Tink: "/System/Library/Sounds/Tink.aiff",
-};
-const WIN_SOUNDS = {
-  "Windows Notify": "C:\\Windows\\Media\\Windows Notify.wav", "tada": "C:\\Windows\\Media\\tada.wav",
-  "chimes": "C:\\Windows\\Media\\chimes.wav", "chord": "C:\\Windows\\Media\\chord.wav",
-  "ding": "C:\\Windows\\Media\\ding.wav", "notify": "C:\\Windows\\Media\\notify.wav",
-  "ringin": "C:\\Windows\\Media\\ringin.wav", "Windows Background": "C:\\Windows\\Media\\Windows Background.wav",
-};
-const LINUX_SOUNDS_DIR = "/usr/share/sounds/freedesktop/stereo";
-const LINUX_SOUNDS = {
-  Basso:     `${LINUX_SOUNDS_DIR}/dialog-warning.oga`,
-  Blow:      `${LINUX_SOUNDS_DIR}/service-logout.oga`,
-  Bottle:    `${LINUX_SOUNDS_DIR}/bell.oga`,
-  Frog:      `${LINUX_SOUNDS_DIR}/message-new-instant.oga`,
-  Funk:      `${LINUX_SOUNDS_DIR}/message-new-instant.oga`,
-  Glass:     `${LINUX_SOUNDS_DIR}/bell.oga`,
-  Hero:      `${LINUX_SOUNDS_DIR}/complete.oga`,
-  Morse:     `${LINUX_SOUNDS_DIR}/message.oga`,
-  Ping:      `${LINUX_SOUNDS_DIR}/message.oga`,
-  Pop:       `${LINUX_SOUNDS_DIR}/dialog-information.oga`,
-  Purr:      `${LINUX_SOUNDS_DIR}/service-login.oga`,
-  Sosumi:    `${LINUX_SOUNDS_DIR}/dialog-warning.oga`,
-  Submarine: `${LINUX_SOUNDS_DIR}/alarm-clock-elapsed.oga`,
-  Tink:      `${LINUX_SOUNDS_DIR}/bell.oga`,
-};
-
-function resolveSound(name, defaultMac, defaultWin) {
-  if (USE_WIN) return WIN_SOUNDS[name] || defaultWin;
-  if (IS_LINUX) return LINUX_SOUNDS[name] || `${LINUX_SOUNDS_DIR}/complete.oga`;
-  return MACOS_SOUNDS[name] || defaultMac;
-}
-
-function readConfig() {
-  try { return JSON.parse(fs.readFileSync(path.join(HOOKS_DIR, "claude-notifier-config.json"), "utf-8")); }
-  catch { return null; }
-}
+// Claude Notifier — PermissionRequest hook (v3)
+// Plays a sound + shows a notification when Claude needs permission to use a tool.
+const { isMuted, readConfig } = require("./_lib/config");
+const { resolveSound } = require("./_lib/sounds");
+const { playSound } = require("./_lib/play");
+const { showNotification } = require("./_lib/notify");
+const { writeSignal } = require("./_lib/signal");
 
 let raw = "";
 process.stdin.setEncoding("utf-8");
@@ -66,55 +14,27 @@ process.stdin.on("end", () => {
   let input = {};
   try { input = JSON.parse(raw); } catch { process.exit(0); }
 
-  if (fs.existsSync(MUTE_FLAG)) process.exit(0);
+  if (isMuted()) process.exit(0);
 
-  // Skip AskUserQuestion — handled by the PreToolUse question hook
+  // AskUserQuestion is handled by the separate PreToolUse question hook.
   if (input.tool_name === "AskUserQuestion") process.exit(0);
 
-  const config = readConfig();
-  const eventCfg = config?.needsPermission ?? {};
-  const level = eventCfg.level ?? "sound+popup";
+  const cfg = readConfig()?.needsPermission ?? {};
+  const level = cfg.level ?? "sound+popup";
 
   if (level === "off") process.exit(0);
 
-  const sound = resolveSound(eventCfg.sound, "/System/Library/Sounds/Glass.aiff", "C:\\Windows\\Media\\Windows Notify.wav");
-
-  // Play sound
   if (level === "sound+popup" || level === "sound") {
-    try {
-      if (USE_WIN) {
-        const ps = `$s='${sound}'; if(Test-Path $s){(New-Object Media.SoundPlayer $s).PlaySync()}else{[console]::Beep(800,300)}`;
-        execSync(`${PS_BIN} -NoProfile -NonInteractive -EncodedCommand ${Buffer.from(ps, "utf16le").toString("base64")}`, { stdio: "ignore", timeout: 5000 });
-      } else if (IS_LINUX) {
-        execSync(`paplay "${sound}" 2>/dev/null || aplay "${sound}" 2>/dev/null`, { stdio: "ignore", timeout: 5000 });
-      } else {
-        execSync(`afplay "${sound}"`, { stdio: "ignore" });
-      }
-    } catch {}
+    const sound = resolveSound(cfg.sound, "/System/Library/Sounds/Glass.aiff", "C:\\Windows\\Media\\Windows Notify.wav");
+    playSound(sound);
   }
 
-  // OS notification
   if (level === "sound+popup" || level === "popup") {
     const tool = input.tool_name || "a tool";
-    const message = `Claude needs permission to use ${tool}.`;
-    try {
-      if (USE_WIN) {
-        const safeMsg = message.replace(/'/g, "''");
-        const ps = `Add-Type -AssemblyName System.Windows.Forms; $n=New-Object System.Windows.Forms.NotifyIcon; $n.Icon=[System.Drawing.SystemIcons]::Information; $n.Visible=$true; $n.ShowBalloonTip(3000,'Claude Notifier','${safeMsg}',[System.Windows.Forms.ToolTipIcon]::None); Start-Sleep -m 500; $n.Dispose()`;
-        execSync(`${PS_BIN} -NoProfile -NonInteractive -EncodedCommand ${Buffer.from(ps, "utf16le").toString("base64")}`, { stdio: "ignore", timeout: 5000 });
-      } else if (IS_LINUX) {
-        const safeMsg = message.replace(/"/g, '\\"');
-        execSync(`notify-send "Claude Notifier" "${safeMsg}" 2>/dev/null`, { stdio: "ignore", timeout: 5000 });
-      } else {
-        execSync(`osascript -e 'display notification "${message}" with title "Claude Notifier"'`, { stdio: "ignore" });
-      }
-    } catch {}
+    showNotification(`Claude needs permission to use ${tool}.`);
   }
 
-  // Write signal for VSCode extension
-  try {
-    fs.writeFileSync(path.join(HOOKS_DIR, "claude-signal"), "input " + Date.now());
-  } catch {}
+  writeSignal("input");
 
   process.exit(0);
 });

--- a/hook/claude-notifier-on-permission.ps1
+++ b/hook/claude-notifier-on-permission.ps1
@@ -1,63 +1,31 @@
-# Claude Notifier - PermissionRequest hook (PowerShell, v2)
-# Plays sound when Claude needs permission.
+# Claude Notifier - PermissionRequest hook (PowerShell, v3)
+# Plays sound + shows notification when Claude needs permission.
 $ErrorActionPreference = 'SilentlyContinue'
-
-$hooksDir = $PSScriptRoot
-$muteFlag = Join-Path $hooksDir 'claude-notifier-muted'
-$configFile = Join-Path $hooksDir 'claude-notifier-config.json'
-
-$winSounds = @{
-    'Windows Notify' = 'C:\Windows\Media\Windows Notify.wav'
-    'tada'           = 'C:\Windows\Media\tada.wav'
-    'chimes'         = 'C:\Windows\Media\chimes.wav'
-    'chord'          = 'C:\Windows\Media\chord.wav'
-    'ding'           = 'C:\Windows\Media\ding.wav'
-    'notify'         = 'C:\Windows\Media\notify.wav'
-    'ringin'         = 'C:\Windows\Media\ringin.wav'
-    'Windows Background' = 'C:\Windows\Media\Windows Background.wav'
-}
+. (Join-Path $PSScriptRoot '_lib.ps1')
 
 $raw = [Console]::In.ReadToEnd()
 try { $data = $raw | ConvertFrom-Json } catch { exit 0 }
 
-if (Test-Path $muteFlag) { exit 0 }
+if (Test-NotifierMuted) { exit 0 }
 
-# Read config
-$config = $null
-try { $config = (Get-Content $configFile -Raw) | ConvertFrom-Json } catch {}
+# AskUserQuestion is handled by the separate PreToolUse question hook.
+if ($data.tool_name -eq 'AskUserQuestion') { exit 0 }
 
-$eventCfg = if ($config -and $config.needsPermission) { $config.needsPermission } else { $null }
-$level = if ($eventCfg -and $eventCfg.level) { $eventCfg.level } else { 'sound+popup' }
+$cfg = (Read-NotifierConfig).needsPermission
+$level = if ($cfg.level) { $cfg.level } else { 'sound+popup' }
 
 if ($level -eq 'off') { exit 0 }
 
-$soundName = if ($eventCfg -and $eventCfg.sound) { $eventCfg.sound } else { '' }
-$soundPath = if ($winSounds.ContainsKey($soundName)) { $winSounds[$soundName] } else { 'C:\Windows\Media\Windows Notify.wav' }
-
-# Play sound
 if ($level -eq 'sound+popup' -or $level -eq 'sound') {
-    try {
-        if (Test-Path $soundPath) { (New-Object Media.SoundPlayer $soundPath).PlaySync() }
-        else { [console]::Beep(800, 300) }
-    } catch {}
+    $sound = Resolve-NotifierSound -Name $cfg.sound -Default 'C:\Windows\Media\Windows Notify.wav'
+    Invoke-NotifierSound -Path $sound
 }
 
-# OS notification
 if ($level -eq 'sound+popup' -or $level -eq 'popup') {
-    try {
-        $tool = if ($data.tool_name) { $data.tool_name } else { 'a tool' }
-        $message = "Claude needs permission to use $tool."
-        Add-Type -AssemblyName System.Windows.Forms
-        $n = New-Object System.Windows.Forms.NotifyIcon
-        $n.Icon = [System.Drawing.SystemIcons]::Information
-        $n.Visible = $true
-        $n.ShowBalloonTip(3000, 'Claude Notifier', $message, [System.Windows.Forms.ToolTipIcon]::None)
-        Start-Sleep -Milliseconds 500
-        $n.Dispose()
-    } catch {}
+    $tool = if ($data.tool_name) { $data.tool_name } else { 'a tool' }
+    Show-NotifierNotification -Message "Claude needs permission to use $tool."
 }
 
-# Write signal for VSCode extension
-try {
-    Set-Content -Path (Join-Path $hooksDir 'claude-signal') -Value "input $(Get-Date -UFormat %s)" -NoNewline
-} catch {}
+Write-NotifierSignal -Reason 'input'
+
+exit 0

--- a/hook/claude-notifier-on-question.js
+++ b/hook/claude-notifier-on-question.js
@@ -1,63 +1,11 @@
 #!/usr/bin/env node
-// Claude Notifier — PreToolUse hook for AskUserQuestion (v2)
-// Plays a sound when Claude asks the user a question.
-const fs = require("fs");
-const path = require("path");
-const { execSync } = require("child_process");
-
-const HOOKS_DIR = path.join(process.env.HOME || process.env.USERPROFILE || "~", ".claude", "hooks");
-const MUTE_FLAG = path.join(HOOKS_DIR, "claude-notifier-muted");
-const IS_WIN = process.platform === "win32";
-const IS_WSL = !IS_WIN && process.platform === "linux" && (() => {
-  try { return fs.readFileSync("/proc/version", "utf-8").toLowerCase().includes("microsoft"); } catch { return false; }
-})();
-const USE_WIN = IS_WIN || IS_WSL;
-const PS_BIN = IS_WSL ? "powershell.exe" : "powershell";
-const IS_LINUX = !IS_WIN && !IS_WSL && process.platform === "linux";
-
-const MACOS_SOUNDS = {
-  Basso: "/System/Library/Sounds/Basso.aiff", Blow: "/System/Library/Sounds/Blow.aiff",
-  Bottle: "/System/Library/Sounds/Bottle.aiff", Frog: "/System/Library/Sounds/Frog.aiff",
-  Funk: "/System/Library/Sounds/Funk.aiff", Glass: "/System/Library/Sounds/Glass.aiff",
-  Hero: "/System/Library/Sounds/Hero.aiff", Morse: "/System/Library/Sounds/Morse.aiff",
-  Ping: "/System/Library/Sounds/Ping.aiff", Pop: "/System/Library/Sounds/Pop.aiff",
-  Purr: "/System/Library/Sounds/Purr.aiff", Sosumi: "/System/Library/Sounds/Sosumi.aiff",
-  Submarine: "/System/Library/Sounds/Submarine.aiff", Tink: "/System/Library/Sounds/Tink.aiff",
-};
-const WIN_SOUNDS = {
-  "Windows Notify": "C:\\Windows\\Media\\Windows Notify.wav", "tada": "C:\\Windows\\Media\\tada.wav",
-  "chimes": "C:\\Windows\\Media\\chimes.wav", "chord": "C:\\Windows\\Media\\chord.wav",
-  "ding": "C:\\Windows\\Media\\ding.wav", "notify": "C:\\Windows\\Media\\notify.wav",
-  "ringin": "C:\\Windows\\Media\\ringin.wav", "Windows Background": "C:\\Windows\\Media\\Windows Background.wav",
-};
-const LINUX_SOUNDS_DIR = "/usr/share/sounds/freedesktop/stereo";
-const LINUX_SOUNDS = {
-  Basso:     `${LINUX_SOUNDS_DIR}/dialog-warning.oga`,
-  Blow:      `${LINUX_SOUNDS_DIR}/service-logout.oga`,
-  Bottle:    `${LINUX_SOUNDS_DIR}/bell.oga`,
-  Frog:      `${LINUX_SOUNDS_DIR}/message-new-instant.oga`,
-  Funk:      `${LINUX_SOUNDS_DIR}/message-new-instant.oga`,
-  Glass:     `${LINUX_SOUNDS_DIR}/bell.oga`,
-  Hero:      `${LINUX_SOUNDS_DIR}/complete.oga`,
-  Morse:     `${LINUX_SOUNDS_DIR}/message.oga`,
-  Ping:      `${LINUX_SOUNDS_DIR}/message.oga`,
-  Pop:       `${LINUX_SOUNDS_DIR}/dialog-information.oga`,
-  Purr:      `${LINUX_SOUNDS_DIR}/service-login.oga`,
-  Sosumi:    `${LINUX_SOUNDS_DIR}/dialog-warning.oga`,
-  Submarine: `${LINUX_SOUNDS_DIR}/alarm-clock-elapsed.oga`,
-  Tink:      `${LINUX_SOUNDS_DIR}/bell.oga`,
-};
-
-function resolveSound(name, defaultMac, defaultWin) {
-  if (USE_WIN) return WIN_SOUNDS[name] || defaultWin;
-  if (IS_LINUX) return LINUX_SOUNDS[name] || `${LINUX_SOUNDS_DIR}/complete.oga`;
-  return MACOS_SOUNDS[name] || defaultMac;
-}
-
-function readConfig() {
-  try { return JSON.parse(fs.readFileSync(path.join(HOOKS_DIR, "claude-notifier-config.json"), "utf-8")); }
-  catch { return null; }
-}
+// Claude Notifier — PreToolUse hook for AskUserQuestion (v3)
+// Plays a sound + shows a notification when Claude asks the user a question.
+const { isMuted, readConfig } = require("./_lib/config");
+const { resolveSound } = require("./_lib/sounds");
+const { playSound } = require("./_lib/play");
+const { showNotification } = require("./_lib/notify");
+const { writeSignal } = require("./_lib/signal");
 
 let raw = "";
 process.stdin.setEncoding("utf-8");
@@ -69,48 +17,23 @@ process.stdin.on("end", () => {
   // Defense-in-depth: bail if a misconfigured matcher routes other tools here.
   if (input.tool_name !== "AskUserQuestion") process.exit(0);
 
-  if (fs.existsSync(MUTE_FLAG)) process.exit(0);
+  if (isMuted()) process.exit(0);
 
-  const config = readConfig();
-  const eventCfg = config?.asksQuestion ?? {};
-  const level = eventCfg.level ?? "sound+popup";
+  const cfg = readConfig()?.asksQuestion ?? {};
+  const level = cfg.level ?? "sound+popup";
 
   if (level === "off") process.exit(0);
 
-  const sound = resolveSound(eventCfg.sound, "/System/Library/Sounds/Funk.aiff", "C:\\Windows\\Media\\Windows Notify.wav");
-
-  // Play sound
   if (level === "sound+popup" || level === "sound") {
-    try {
-      if (USE_WIN) {
-        const ps = `$s='${sound}'; if(Test-Path $s){(New-Object Media.SoundPlayer $s).PlaySync()}else{[console]::Beep(800,300)}`;
-        execSync(`${PS_BIN} -NoProfile -NonInteractive -EncodedCommand ${Buffer.from(ps, "utf16le").toString("base64")}`, { stdio: "ignore", timeout: 5000 });
-      } else if (IS_LINUX) {
-        execSync(`paplay "${sound}" 2>/dev/null || aplay "${sound}" 2>/dev/null`, { stdio: "ignore", timeout: 5000 });
-      } else {
-        execSync(`afplay "${sound}"`, { stdio: "ignore" });
-      }
-    } catch {}
+    const sound = resolveSound(cfg.sound, "/System/Library/Sounds/Funk.aiff", "C:\\Windows\\Media\\Windows Notify.wav");
+    playSound(sound);
   }
 
-  // OS notification
   if (level === "sound+popup" || level === "popup") {
-    try {
-      if (USE_WIN) {
-        const ps = `Add-Type -AssemblyName System.Windows.Forms; $n=New-Object System.Windows.Forms.NotifyIcon; $n.Icon=[System.Drawing.SystemIcons]::Information; $n.Visible=$true; $n.ShowBalloonTip(3000,'Claude Notifier','Claude is asking you a question.',[System.Windows.Forms.ToolTipIcon]::None); Start-Sleep -m 500; $n.Dispose()`;
-        execSync(`${PS_BIN} -NoProfile -NonInteractive -EncodedCommand ${Buffer.from(ps, "utf16le").toString("base64")}`, { stdio: "ignore", timeout: 5000 });
-      } else if (IS_LINUX) {
-        execSync(`notify-send "Claude Notifier" "Claude is asking you a question." 2>/dev/null`, { stdio: "ignore", timeout: 5000 });
-      } else {
-        execSync(`osascript -e 'display notification "Claude is asking you a question." with title "Claude Notifier"'`, { stdio: "ignore" });
-      }
-    } catch {}
+    showNotification("Claude is asking you a question.");
   }
 
-  // Write signal for VSCode extension
-  try {
-    fs.writeFileSync(path.join(HOOKS_DIR, "claude-signal"), "question " + Date.now());
-  } catch {}
+  writeSignal("question");
 
   process.exit(0);
 });

--- a/hook/claude-notifier-on-question.ps1
+++ b/hook/claude-notifier-on-question.ps1
@@ -1,21 +1,7 @@
-# Claude Notifier - PreToolUse hook for AskUserQuestion (PowerShell, v2)
-# Plays sound when Claude asks the user a question.
+# Claude Notifier - PreToolUse hook for AskUserQuestion (PowerShell, v3)
+# Plays sound + shows notification when Claude asks the user a question.
 $ErrorActionPreference = 'SilentlyContinue'
-
-$hooksDir = $PSScriptRoot
-$muteFlag = Join-Path $hooksDir 'claude-notifier-muted'
-$configFile = Join-Path $hooksDir 'claude-notifier-config.json'
-
-$winSounds = @{
-    'Windows Notify' = 'C:\Windows\Media\Windows Notify.wav'
-    'tada'           = 'C:\Windows\Media\tada.wav'
-    'chimes'         = 'C:\Windows\Media\chimes.wav'
-    'chord'          = 'C:\Windows\Media\chord.wav'
-    'ding'           = 'C:\Windows\Media\ding.wav'
-    'notify'         = 'C:\Windows\Media\notify.wav'
-    'ringin'         = 'C:\Windows\Media\ringin.wav'
-    'Windows Background' = 'C:\Windows\Media\Windows Background.wav'
-}
+. (Join-Path $PSScriptRoot '_lib.ps1')
 
 $raw = [Console]::In.ReadToEnd()
 try { $data = $raw | ConvertFrom-Json } catch { exit 0 }
@@ -23,42 +9,22 @@ try { $data = $raw | ConvertFrom-Json } catch { exit 0 }
 # Defense-in-depth: bail if a misconfigured matcher routes other tools here.
 if ($data.tool_name -ne 'AskUserQuestion') { exit 0 }
 
-if (Test-Path $muteFlag) { exit 0 }
+if (Test-NotifierMuted) { exit 0 }
 
-# Read config
-$config = $null
-try { $config = (Get-Content $configFile -Raw) | ConvertFrom-Json } catch {}
-
-$eventCfg = if ($config -and $config.asksQuestion) { $config.asksQuestion } else { $null }
-$level = if ($eventCfg -and $eventCfg.level) { $eventCfg.level } else { 'sound+popup' }
+$cfg = (Read-NotifierConfig).asksQuestion
+$level = if ($cfg.level) { $cfg.level } else { 'sound+popup' }
 
 if ($level -eq 'off') { exit 0 }
 
-$soundName = if ($eventCfg -and $eventCfg.sound) { $eventCfg.sound } else { '' }
-$soundPath = if ($winSounds.ContainsKey($soundName)) { $winSounds[$soundName] } else { 'C:\Windows\Media\Windows Notify.wav' }
-
-# Play sound
 if ($level -eq 'sound+popup' -or $level -eq 'sound') {
-    try {
-        if (Test-Path $soundPath) { (New-Object Media.SoundPlayer $soundPath).PlaySync() }
-        else { [console]::Beep(800, 300) }
-    } catch {}
+    $sound = Resolve-NotifierSound -Name $cfg.sound -Default 'C:\Windows\Media\Windows Notify.wav'
+    Invoke-NotifierSound -Path $sound
 }
 
-# OS notification
 if ($level -eq 'sound+popup' -or $level -eq 'popup') {
-    try {
-        Add-Type -AssemblyName System.Windows.Forms
-        $n = New-Object System.Windows.Forms.NotifyIcon
-        $n.Icon = [System.Drawing.SystemIcons]::Information
-        $n.Visible = $true
-        $n.ShowBalloonTip(3000, 'Claude Notifier', 'Claude is asking you a question.', [System.Windows.Forms.ToolTipIcon]::None)
-        Start-Sleep -Milliseconds 500
-        $n.Dispose()
-    } catch {}
+    Show-NotifierNotification -Message 'Claude is asking you a question.'
 }
 
-# Write signal for VSCode extension
-try {
-    Set-Content -Path (Join-Path $hooksDir 'claude-signal') -Value "question $(Get-Date -UFormat %s)" -NoNewline
-} catch {}
+Write-NotifierSignal -Reason 'question'
+
+exit 0

--- a/hook/claude-notifier-on-stop.js
+++ b/hook/claude-notifier-on-stop.js
@@ -1,112 +1,14 @@
 #!/usr/bin/env node
-// Claude Notifier — Stop hook script (v3)
+// Claude Notifier — Stop hook (v4)
 // Writes a "done" signal for the VSCode extension to debounce. When no
-// extension is active (terminal-only), plays sound/notification directly as
-// a fallback. Each active extension window writes a PID marker file into
-// claude-notifier-active.d/; the hook only defers when a marker names a
-// live process, so a crashed extension doesn't silence terminal fallback.
-const fs = require("fs");
-const path = require("path");
-const { execSync } = require("child_process");
-
-const HOOKS_DIR = path.join(process.env.HOME || process.env.USERPROFILE || "~", ".claude", "hooks");
-const MUTE_FLAG = path.join(HOOKS_DIR, "claude-notifier-muted");
-const SIGNAL_FILE = path.join(HOOKS_DIR, "claude-signal");
-const ACTIVE_DIR = path.join(HOOKS_DIR, "claude-notifier-active.d");
-
-function findTerminalNotifier() {
-  if (process.platform !== "darwin") return null;
-  for (const c of ["/opt/homebrew/bin/terminal-notifier", "/usr/local/bin/terminal-notifier"]) {
-    try { fs.accessSync(c, fs.constants.X_OK); return c; } catch {}
-  }
-  try {
-    const out = require("child_process").execFileSync("/usr/bin/which", ["terminal-notifier"], { encoding: "utf-8" }).trim();
-    if (out) return out;
-  } catch {}
-  return null;
-}
-
-function cwdInsideFolder(cwd, folder) {
-  if (!cwd || !folder) return false;
-  if (cwd === folder) return true;
-  const sep = path.sep;
-  return cwd.startsWith(folder.endsWith(sep) ? folder : folder + sep);
-}
-
-// Returns true if any live extension owns this cwd (i.e. its window has a
-// matching workspace folder). When no extension claims the cwd — for example
-// a Claude session running in a terminal that's not inside any open VS Code
-// workspace — we fall through to terminal-fallback notifications.
-function extensionOwnsCwd(cwd) {
-  let entries;
-  try { entries = fs.readdirSync(ACTIVE_DIR); } catch { return false; }
-  for (const name of entries) {
-    const pid = parseInt(name, 10);
-    if (!Number.isFinite(pid)) continue;
-    try { process.kill(pid, 0); } catch { continue; }
-    let folders = "";
-    try { folders = fs.readFileSync(path.join(ACTIVE_DIR, name), "utf-8"); } catch {}
-    // Backwards-compat: empty PID file means a pre-cwd-routing extension is
-    // running. Defer to it for any signal — once that window reloads, the
-    // file gets a workspace list and proper routing kicks in.
-    if (!folders.trim()) return true;
-    for (const folder of folders.split("\n").map((s) => s.trim()).filter(Boolean)) {
-      if (cwdInsideFolder(cwd, folder)) return true;
-    }
-  }
-  return false;
-}
-const IS_WIN = process.platform === "win32";
-const IS_WSL = !IS_WIN && process.platform === "linux" && (() => {
-  try { return fs.readFileSync("/proc/version", "utf-8").toLowerCase().includes("microsoft"); } catch { return false; }
-})();
-const USE_WIN = IS_WIN || IS_WSL;
-const PS_BIN = IS_WSL ? "powershell.exe" : "powershell";
-const IS_LINUX = !IS_WIN && !IS_WSL && process.platform === "linux";
-
-const MACOS_SOUNDS = {
-  Basso: "/System/Library/Sounds/Basso.aiff", Blow: "/System/Library/Sounds/Blow.aiff",
-  Bottle: "/System/Library/Sounds/Bottle.aiff", Frog: "/System/Library/Sounds/Frog.aiff",
-  Funk: "/System/Library/Sounds/Funk.aiff", Glass: "/System/Library/Sounds/Glass.aiff",
-  Hero: "/System/Library/Sounds/Hero.aiff", Morse: "/System/Library/Sounds/Morse.aiff",
-  Ping: "/System/Library/Sounds/Ping.aiff", Pop: "/System/Library/Sounds/Pop.aiff",
-  Purr: "/System/Library/Sounds/Purr.aiff", Sosumi: "/System/Library/Sounds/Sosumi.aiff",
-  Submarine: "/System/Library/Sounds/Submarine.aiff", Tink: "/System/Library/Sounds/Tink.aiff",
-};
-const WIN_SOUNDS = {
-  "Windows Notify": "C:\\Windows\\Media\\Windows Notify.wav", "tada": "C:\\Windows\\Media\\tada.wav",
-  "chimes": "C:\\Windows\\Media\\chimes.wav", "chord": "C:\\Windows\\Media\\chord.wav",
-  "ding": "C:\\Windows\\Media\\ding.wav", "notify": "C:\\Windows\\Media\\notify.wav",
-  "ringin": "C:\\Windows\\Media\\ringin.wav", "Windows Background": "C:\\Windows\\Media\\Windows Background.wav",
-};
-const LINUX_SOUNDS_DIR = "/usr/share/sounds/freedesktop/stereo";
-const LINUX_SOUNDS = {
-  Basso:     `${LINUX_SOUNDS_DIR}/dialog-warning.oga`,
-  Blow:      `${LINUX_SOUNDS_DIR}/service-logout.oga`,
-  Bottle:    `${LINUX_SOUNDS_DIR}/bell.oga`,
-  Frog:      `${LINUX_SOUNDS_DIR}/message-new-instant.oga`,
-  Funk:      `${LINUX_SOUNDS_DIR}/message-new-instant.oga`,
-  Glass:     `${LINUX_SOUNDS_DIR}/bell.oga`,
-  Hero:      `${LINUX_SOUNDS_DIR}/complete.oga`,
-  Morse:     `${LINUX_SOUNDS_DIR}/message.oga`,
-  Ping:      `${LINUX_SOUNDS_DIR}/message.oga`,
-  Pop:       `${LINUX_SOUNDS_DIR}/dialog-information.oga`,
-  Purr:      `${LINUX_SOUNDS_DIR}/service-login.oga`,
-  Sosumi:    `${LINUX_SOUNDS_DIR}/dialog-warning.oga`,
-  Submarine: `${LINUX_SOUNDS_DIR}/alarm-clock-elapsed.oga`,
-  Tink:      `${LINUX_SOUNDS_DIR}/bell.oga`,
-};
-
-function resolveSound(name, defaultMac, defaultWin) {
-  if (USE_WIN) return WIN_SOUNDS[name] || defaultWin;
-  if (IS_LINUX) return LINUX_SOUNDS[name] || `${LINUX_SOUNDS_DIR}/complete.oga`;
-  return MACOS_SOUNDS[name] || defaultMac;
-}
-
-function readConfig() {
-  try { return JSON.parse(fs.readFileSync(path.join(HOOKS_DIR, "claude-notifier-config.json"), "utf-8")); }
-  catch { return null; }
-}
+// extension is active (terminal-only Claude session, or session outside any
+// open workspace), plays sound/notification directly as a fallback.
+const { isMuted, readConfig } = require("./_lib/config");
+const { resolveSound } = require("./_lib/sounds");
+const { playSound } = require("./_lib/play");
+const { showNotification } = require("./_lib/notify");
+const { extensionOwnsCwd } = require("./_lib/active");
+const { writeSignal } = require("./_lib/signal");
 
 let raw = "";
 process.stdin.setEncoding("utf-8");
@@ -116,61 +18,30 @@ process.stdin.on("end", () => {
   try { input = JSON.parse(raw); } catch { process.exit(0); }
 
   if (input.stop_hook_active) process.exit(0);
-  if (fs.existsSync(MUTE_FLAG)) process.exit(0);
+  if (isMuted()) process.exit(0);
 
   const cwd = (input && input.cwd) || process.cwd() || "";
 
-  // Write signal for the VSCode extension (which debounces "done" signals
-  // and routes them to the matching window via cwd).
-  try {
-    fs.writeFileSync(SIGNAL_FILE, `done ${Date.now()} ${cwd}`);
-  } catch {}
+  writeSignal("done", cwd);
 
   // If a VSCode window owns this cwd, the extension handles sound/notification
-  // with debounce. Otherwise (terminal Claude or unrelated workspace) we play
-  // directly here.
+  // with debounce. Otherwise fall through to direct playback.
   if (extensionOwnsCwd(cwd)) process.exit(0);
 
-  const config = readConfig();
-  const eventCfg = config?.taskCompleted ?? {};
-  const level = eventCfg.level ?? "sound+popup";
+  const cfg = readConfig()?.taskCompleted ?? {};
+  const level = cfg.level ?? "sound+popup";
 
   if (level === "off") process.exit(0);
 
-  const sound = resolveSound(eventCfg.sound, "/System/Library/Sounds/Hero.aiff", "C:\\Windows\\Media\\tada.wav");
-
   if (level === "sound+popup" || level === "sound") {
-    try {
-      if (USE_WIN) {
-        const ps = `$s='${sound}'; if(Test-Path $s){(New-Object Media.SoundPlayer $s).PlaySync()}else{[console]::Beep(800,300)}`;
-        execSync(`${PS_BIN} -NoProfile -NonInteractive -EncodedCommand ${Buffer.from(ps, "utf16le").toString("base64")}`, { stdio: "ignore", timeout: 5000 });
-      } else if (IS_LINUX) {
-        execSync(`paplay "${sound}" 2>/dev/null || aplay "${sound}" 2>/dev/null`, { stdio: "ignore", timeout: 5000 });
-      } else {
-        execSync(`afplay "${sound}"`, { stdio: "ignore" });
-      }
-    } catch {}
+    const sound = resolveSound(cfg.sound, "/System/Library/Sounds/Hero.aiff", "C:\\Windows\\Media\\tada.wav");
+    playSound(sound);
   }
 
   if (level === "sound+popup" || level === "popup") {
-    try {
-      if (USE_WIN) {
-        const ps = `Add-Type -AssemblyName System.Windows.Forms; $n=New-Object System.Windows.Forms.NotifyIcon; $n.Icon=[System.Drawing.SystemIcons]::Information; $n.Visible=$true; $n.ShowBalloonTip(3000,'Claude Notifier','Claude has finished the task.',[System.Windows.Forms.ToolTipIcon]::None); Start-Sleep -m 500; $n.Dispose()`;
-        execSync(`${PS_BIN} -NoProfile -NonInteractive -EncodedCommand ${Buffer.from(ps, "utf16le").toString("base64")}`, { stdio: "ignore", timeout: 5000 });
-      } else if (IS_LINUX) {
-        execSync(`notify-send "Claude Notifier" "Claude has finished the task." 2>/dev/null`, { stdio: "ignore", timeout: 5000 });
-      } else {
-        const tn = findTerminalNotifier();
-        if (tn) {
-          require("child_process").execFileSync(tn, [
-            "-title", "Claude Notifier",
-            "-message", "Claude has finished the task.",
-          ], { stdio: "ignore" });
-        } else {
-          execSync(`osascript -e 'display notification "Claude has finished the task." with title "Claude Notifier"'`, { stdio: "ignore" });
-        }
-      }
-    } catch {}
+    // Stop notifications fire when the user is likely away — prefer
+    // terminal-notifier so the click can focus VS Code.
+    showNotification("Claude has finished the task.", { preferTerminalNotifier: true });
   }
 
   process.exit(0);

--- a/hook/claude-notifier-on-stop.ps1
+++ b/hook/claude-notifier-on-stop.ps1
@@ -1,103 +1,37 @@
-# Claude Notifier - Stop hook (PowerShell, v3)
+# Claude Notifier - Stop hook (PowerShell, v4)
 # Writes a "done" signal for the VSCode extension to debounce. When no
 # extension is active (terminal-only), plays sound/notification directly.
 $ErrorActionPreference = 'SilentlyContinue'
-
-$hooksDir = $PSScriptRoot
-$muteFlag = Join-Path $hooksDir 'claude-notifier-muted'
-$signalFile = Join-Path $hooksDir 'claude-signal'
-$activeDir  = Join-Path $hooksDir 'claude-notifier-active.d'
-$configFile = Join-Path $hooksDir 'claude-notifier-config.json'
-
-# Extension writes one PID marker file per window into $activeDir. The file's
-# content is the window's workspace folder list (one per line). Only treat
-# the extension as the owner of a Stop signal when a live PID's workspace
-# contains the firing cwd — otherwise fall through to terminal fallback so
-# Claude sessions outside any open workspace still get notified.
-function Test-CwdInsideFolder([string]$cwd, [string]$folder) {
-    if (-not $cwd -or -not $folder) { return $false }
-    if ($cwd -eq $folder) { return $true }
-    $sep = [IO.Path]::DirectorySeparatorChar
-    if (-not $folder.EndsWith($sep)) { $folder = $folder + $sep }
-    return $cwd.StartsWith($folder)
-}
-
-function Test-ExtensionOwnsCwd([string]$cwd) {
-    if (-not (Test-Path $activeDir)) { return $false }
-    foreach ($f in Get-ChildItem -Path $activeDir -File -ErrorAction SilentlyContinue) {
-        $pidVal = 0
-        if (-not [int]::TryParse($f.Name, [ref]$pidVal)) { continue }
-        if (-not (Get-Process -Id $pidVal -ErrorAction SilentlyContinue)) { continue }
-        $folders = ""
-        try { $folders = [IO.File]::ReadAllText($f.FullName) } catch {}
-        # Backwards-compat: empty marker means a pre-cwd-routing extension is
-        # running. Defer to it; once it reloads the marker will be populated.
-        if (-not $folders.Trim()) { return $true }
-        foreach ($line in $folders -split "`n") {
-            $folder = $line.Trim()
-            if ($folder -and (Test-CwdInsideFolder $cwd $folder)) { return $true }
-        }
-    }
-    return $false
-}
-
-$winSounds = @{
-    'Windows Notify' = 'C:\Windows\Media\Windows Notify.wav'
-    'tada'           = 'C:\Windows\Media\tada.wav'
-    'chimes'         = 'C:\Windows\Media\chimes.wav'
-    'chord'          = 'C:\Windows\Media\chord.wav'
-    'ding'           = 'C:\Windows\Media\ding.wav'
-    'notify'         = 'C:\Windows\Media\notify.wav'
-    'ringin'         = 'C:\Windows\Media\ringin.wav'
-    'Windows Background' = 'C:\Windows\Media\Windows Background.wav'
-}
+. (Join-Path $PSScriptRoot '_lib.ps1')
 
 $raw = [Console]::In.ReadToEnd()
 try { $data = $raw | ConvertFrom-Json } catch { exit 0 }
 
 if ($data.stop_hook_active) { exit 0 }
-if (Test-Path $muteFlag) { exit 0 }
+if (Test-NotifierMuted) { exit 0 }
 
 $cwd = ""
 if ($data.cwd) { $cwd = "$($data.cwd)" }
 if (-not $cwd) { $cwd = (Get-Location).Path }
 
-# Write signal for the VSCode extension (which debounces "done" signals
-# and routes them to the matching window via cwd).
-try {
-    Set-Content -Path $signalFile -Value "done $(Get-Date -UFormat %s) $cwd" -NoNewline
-} catch {}
+Write-NotifierSignal -Reason 'done' -Cwd $cwd
 
-# If a VSCode window owns this cwd, the extension handles it. Otherwise
-# (terminal Claude or unrelated workspace) play directly here.
+# If a VSCode window owns this cwd, the extension handles sound/notification
+# with debounce. Otherwise fall through to direct playback.
 if (Test-ExtensionOwnsCwd $cwd) { exit 0 }
 
-$config = $null
-try { $config = (Get-Content $configFile -Raw) | ConvertFrom-Json } catch {}
-
-$eventCfg = if ($config -and $config.taskCompleted) { $config.taskCompleted } else { $null }
-$level = if ($eventCfg -and $eventCfg.level) { $eventCfg.level } else { 'sound+popup' }
+$cfg = (Read-NotifierConfig).taskCompleted
+$level = if ($cfg.level) { $cfg.level } else { 'sound+popup' }
 
 if ($level -eq 'off') { exit 0 }
 
-$soundName = if ($eventCfg -and $eventCfg.sound) { $eventCfg.sound } else { '' }
-$soundPath = if ($winSounds.ContainsKey($soundName)) { $winSounds[$soundName] } else { 'C:\Windows\Media\tada.wav' }
-
 if ($level -eq 'sound+popup' -or $level -eq 'sound') {
-    try {
-        if (Test-Path $soundPath) { (New-Object Media.SoundPlayer $soundPath).PlaySync() }
-        else { [console]::Beep(800, 300) }
-    } catch {}
+    $sound = Resolve-NotifierSound -Name $cfg.sound -Default 'C:\Windows\Media\tada.wav'
+    Invoke-NotifierSound -Path $sound
 }
 
 if ($level -eq 'sound+popup' -or $level -eq 'popup') {
-    try {
-        Add-Type -AssemblyName System.Windows.Forms
-        $n = New-Object System.Windows.Forms.NotifyIcon
-        $n.Icon = [System.Drawing.SystemIcons]::Information
-        $n.Visible = $true
-        $n.ShowBalloonTip(3000, 'Claude Notifier', 'Claude has finished the task.', [System.Windows.Forms.ToolTipIcon]::None)
-        Start-Sleep -Milliseconds 500
-        $n.Dispose()
-    } catch {}
+    Show-NotifierNotification -Message 'Claude has finished the task.'
 }
+
+exit 0

--- a/install.sh
+++ b/install.sh
@@ -18,11 +18,16 @@ REPO_RAW="https://raw.githubusercontent.com/ashmitb95/claude-notifier/main"
 
 echo "Installing Claude Notifier..."
 
-mkdir -p "$HOOKS_DIR"
+mkdir -p "$HOOKS_DIR" "$HOOKS_DIR/_lib"
 
 for script in claude-notifier-on-stop.js claude-notifier-on-permission.js claude-notifier-on-question.js; do
   curl -fsSL "$REPO_RAW/hook/$script" -o "$HOOKS_DIR/$script"
   chmod +x "$HOOKS_DIR/$script"
+done
+
+# Shared hook library (required by the hook scripts since v3.0)
+for lib in platform.js paths.js sounds.js config.js play.js notify.js signal.js active.js; do
+  curl -fsSL "$REPO_RAW/hook/_lib/$lib" -o "$HOOKS_DIR/_lib/$lib"
 done
 
 if [ ! -f "$SETTINGS_FILE" ]; then

--- a/src/hooks/lifecycle.ts
+++ b/src/hooks/lifecycle.ts
@@ -20,6 +20,11 @@ const HOOK_RUNNER_PREFIX = IS_WIN ? "powershell" : "node";
 export function setupHooks(extensionPath: string): void {
   fs.mkdirSync(HOOKS_DIR, { recursive: true });
 
+  // Copy shared hook library FIRST so the newly-slim hook scripts never run
+  // without their `_lib/` available. On macOS/Linux/WSL the hook scripts
+  // `require("./_lib/*.js")`; on Windows they `. _lib.ps1`. Bundled by .vsix.
+  copyHookLib(extensionPath);
+
   // Copy bundled hook scripts (only if changed)
   for (const hook of HOOKS) {
     const src = path.join(extensionPath, "hook", `${hook.baseName}${IS_WIN ? ".ps1" : ".js"}`);
@@ -67,6 +72,32 @@ export function setupHooks(extensionPath: string): void {
   writeSettings(settings);
 }
 
+function copyHookLib(extensionPath: string): void {
+  if (IS_WIN) {
+    syncFile(
+      path.join(extensionPath, "hook", "_lib.ps1"),
+      path.join(HOOKS_DIR, "_lib.ps1")
+    );
+    return;
+  }
+  const libSrcDir = path.join(extensionPath, "hook", "_lib");
+  const libDestDir = path.join(HOOKS_DIR, "_lib");
+  fs.mkdirSync(libDestDir, { recursive: true });
+  for (const entry of fs.readdirSync(libSrcDir)) {
+    if (!entry.endsWith(".js")) continue;
+    syncFile(path.join(libSrcDir, entry), path.join(libDestDir, entry));
+  }
+}
+
+function syncFile(src: string, dest: string): void {
+  const srcContent = fs.readFileSync(src, "utf-8");
+  let destContent = "";
+  try { destContent = fs.readFileSync(dest, "utf-8"); } catch {}
+  if (srcContent !== destContent) {
+    fs.writeFileSync(dest, srcContent);
+  }
+}
+
 /**
  * Full uninstall: remove hook files (including legacy/cross-platform
  * variants), state files, PID-marker directory, legacy shim artifacts, and
@@ -103,6 +134,16 @@ export function teardownHooks(): void {
       try { fs.unlinkSync(path.join(ACTIVE_DIR, name)); } catch {}
     }
     fs.rmdirSync(ACTIVE_DIR);
+  } catch {}
+
+  // Shared hook library: _lib/*.js (mac/linux/wsl) and _lib.ps1 (win)
+  try { fs.unlinkSync(path.join(HOOKS_DIR, "_lib.ps1")); } catch {}
+  try {
+    const libDir = path.join(HOOKS_DIR, "_lib");
+    for (const entry of fs.readdirSync(libDir)) {
+      try { fs.unlinkSync(path.join(libDir, entry)); } catch {}
+    }
+    fs.rmdirSync(libDir);
   } catch {}
 
   // Older versions shipped a generated AppleScript shim — remove if present.

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -15,6 +15,8 @@ echo "Uninstalling Claude Notifier..."
 rm -f "$HOOKS_DIR"/claude-notifier-on-*.js
 rm -f "$HOOKS_DIR/claude-notifier-muted"
 rm -f "$HOOKS_DIR/claude-signal"
+rm -f "$HOOKS_DIR/claude-notifier-config.json"
+rm -rf "$HOOKS_DIR/_lib"
 
 if [ -f "$SETTINGS_FILE" ]; then
   node -e "


### PR DESCRIPTION
## Summary

Phase 2 of the staging-branch rebuild. Extracts the duplicated platform detection, sound maps, config read, mute check, sound playback, and notification logic out of the 4 hook scripts into a shared library.

**New structure** (bundled in the .vsix, deployed to \`~/.claude/hooks/\` alongside the hook scripts):

\`\`\`
hook/
├── _lib/                      # Node.js — used by .js hooks
│   ├── platform.js            #   IS_WIN / IS_WSL / IS_LINUX / IS_MAC + PS_BIN
│   ├── paths.js               #   HOOKS_DIR, MUTE_FLAG, SIGNAL_FILE, …
│   ├── sounds.js              #   MACOS/WIN/LINUX maps + resolveSound()
│   ├── config.js              #   readConfig() + isMuted()
│   ├── play.js                #   playSound() — 3-OS branching
│   ├── notify.js              #   showNotification() — safer escaping
│   ├── signal.js              #   writeSignal(reason, cwd?)
│   └── active.js              #   extensionOwnsCwd() PID liveness check
├── _lib.ps1                   # Single dot-sourced file — used by .ps1 hooks
└── claude-notifier-on-{stop,permission,question,notification}.{js,ps1}
\`\`\`

## Hook script sizes

| | .js (was) | .js (now) | .ps1 (was) | .ps1 (now) |
|---|---|---|---|---|
| on-stop | 8.04 KB | 1.75 KB | 4.27 KB | 1.20 KB |
| on-permission | 5.57 KB | 1.33 KB | 2.35 KB | 1.03 KB |
| on-question | 5.43 KB | 1.29 KB | 2.39 KB | 0.98 KB |
| on-notification | 2.95 KB | 1.24 KB | 1.21 KB | 0.67 KB |

Net payload is essentially unchanged (the lib files add ~13 KB), but **shared logic now has one source of truth** — fixes and platform additions no longer need to be replicated across four files. The recent Linux support PR (#13) is exactly the kind of change that previously had to touch all four .js hooks; next time it touches one place.

## Latent shell-injection bugs fixed in passing

The Phase 2 plan called for the audit-flagged shell escaping bugs to be fixed in the lib:

- **Linux notify-send** now uses \`execFileSync()\` to bypass the shell — \`$\`, backticks, backslashes in tool names can no longer break the command (or be exploited).
- **macOS osascript** also uses \`execFileSync()\`, with AppleScript-level \`\\\` and \`\"\` escaping. Previously the message was interpolated raw into the \`-e\` argument.
- **PowerShell** single-quote escape was already correct (\`s.replace(/'/g, \"''\")\`) and is preserved.

## Extension and installer changes

- **\`src/hooks/lifecycle.ts\`**: \`setupHooks\` copies \`_lib/\` (or \`_lib.ps1\` on Windows) **before** the hook scripts, so the slim hooks never run without their library. Idempotent: a \`syncFile()\` helper skips writes when content is unchanged. \`teardownHooks\` cleans up the lib files.
- **\`install.sh\`**: also downloads \`hook/_lib/*.js\` into \`~/.claude/hooks/_lib/\`.
- **\`uninstall.sh\`**: removes \`~/.claude/hooks/_lib\` and the config file.

## Verification

- \`npm run compile\` clean.
- \`npm run package\` builds 59-file .vsix (was 50 — the 9 extra are the lib files + their sourcemaps), 119 KB.
- All 4 .js hooks smoke-tested via synthetic stdin → correct signal-file content (\`done <ts> <cwd>\`, \`input <ts>\`, \`question <ts>\`).
- AskUserQuestion correctly skipped by the permission hook.
- Non-AskUserQuestion correctly skipped by the question hook.
- Mute flag short-circuit preserved.

## Test plan

- [ ] **Reload VS Code** with the new .vsix (already sideloaded). On activation, the extension should:
  1. Copy \`_lib/*.js\` into \`~/.claude/hooks/_lib/\`.
  2. Overwrite the old hook scripts with the slim new ones.
  3. Hooks should fire correctly via real Claude Code runs (Stop, PermissionRequest, AskUserQuestion).
- [ ] Run \`/test-notifier\` to walk the full 9-step smoke procedure.
- [ ] **Cannot validate locally**: the .ps1 lib on Windows. Idioms mirror the existing .ps1 patterns (PSScriptRoot, Get-Date -UFormat %s, [Console]::In.ReadToEnd, etc.); a Windows tester would be welcome before final \`staging → main\` merge.