### PR TITLE
feat: per-session stage dedup + output channel

### DIFF
--- a/hook/_lib.ps1
+++ b/hook/_lib.ps1
@@ -79,12 +79,15 @@ function Show-NotifierNotification([string]$Message) {
     } catch {}
 }
 
-# Write a signal for the extension. Format: "<reason> <unix-secs> [cwd]".
-# Matches the existing PS1 timestamp format (seconds, not ms).
-function Write-NotifierSignal([string]$Reason, [string]$Cwd) {
+# Write a signal for the extension.
+# Format v2: "<reason> <ts> <session_id|-> [cwd]" (matches hook/_lib/signal.js).
+# Session id is whitespace-stripped; "-" when absent.
+function Write-NotifierSignal([string]$Reason, [string]$SessionId, [string]$Cwd) {
     try {
         $ts = (Get-Date -UFormat %s)
-        $payload = if ($Cwd) { "$Reason $ts $Cwd" } else { "$Reason $ts" }
+        $sid = if ($SessionId) { ($SessionId -replace '\s+', '') } else { '-' }
+        if (-not $sid) { $sid = '-' }
+        $payload = if ($Cwd) { "$Reason $ts $sid $Cwd" } else { "$Reason $ts $sid" }
         Set-Content -Path $LibSignalFile -Value $payload -NoNewline
     } catch {}
 }

--- a/hook/_lib/signal.js
+++ b/hook/_lib/signal.js
@@ -2,12 +2,27 @@ const fs = require("fs");
 const { SIGNAL_FILE } = require("./paths");
 
 /**
- * Write a signal for the extension to consume. Format: "<reason> <ts> <cwd?>".
- * cwd is optional — Stop includes it for per-window routing; others omit it.
+ * Write a signal for the extension to consume.
+ *
+ * Format v2 (current): "<reason> <ts> <session_id|-> <cwd?>"
+ *   session_id is a single token (no whitespace); "-" when absent.
+ *   cwd is optional — Stop includes it for per-window routing; others omit it.
+ *
+ * Format v1 (legacy): "<reason> <ts> <cwd?>"
+ *   Still accepted by the parser for back-compat with older deployed hooks.
+ *   New writes always use v2.
  */
-function writeSignal(reason, cwd) {
+function writeSignal(reason, sessionId, cwd) {
   try {
-    const payload = cwd ? `${reason} ${Date.now()} ${cwd}` : `${reason} ${Date.now()}`;
+    const ts = Date.now();
+    // Session id may contain anything Claude Code chooses to send. Strip
+    // whitespace defensively so the space-delimited signal format stays
+    // parseable. Empty/missing → "-".
+    const sid = sessionId ? String(sessionId).replace(/\s+/g, "") : "-";
+    const safeSid = sid || "-";
+    const payload = cwd
+      ? `${reason} ${ts} ${safeSid} ${cwd}`
+      : `${reason} ${ts} ${safeSid}`;
     fs.writeFileSync(SIGNAL_FILE, payload);
   } catch {}
 }

--- a/hook/claude-notifier-on-notification.js
+++ b/hook/claude-notifier-on-notification.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// Claude Notifier — Notification hook (v2)
+// Claude Notifier — Notification hook
 // Plays the "needs input" sound when Claude posts a permission_prompt
 // notification. Uses fixed sound (not config-driven) — this hook fires
 // before the PermissionRequest hook can react.
@@ -27,7 +27,7 @@ process.stdin.on("end", () => {
   const message = input.message || "Claude needs your permission.";
   showNotification(message);
 
-  writeSignal("input");
+  writeSignal("input", input.session_id);
 
   process.exit(0);
 });

--- a/hook/claude-notifier-on-notification.ps1
+++ b/hook/claude-notifier-on-notification.ps1
@@ -1,4 +1,4 @@
-# Claude Notifier - Notification hook (PowerShell, v2)
+# Claude Notifier - Notification hook (PowerShell)
 # Plays sound + shows notification on permission_prompt notifications.
 # Uses fixed sound (not config-driven).
 $ErrorActionPreference = 'SilentlyContinue'
@@ -15,6 +15,6 @@ Invoke-NotifierSound -Path 'C:\Windows\Media\Windows Notify.wav' -Fallback $LibB
 $message = if ($data.message) { $data.message } else { 'Claude needs your permission.' }
 Show-NotifierNotification -Message $message
 
-Write-NotifierSignal -Reason 'input'
+Write-NotifierSignal -Reason 'input' -SessionId $data.session_id
 
 exit 0

--- a/hook/claude-notifier-on-permission.js
+++ b/hook/claude-notifier-on-permission.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// Claude Notifier — PermissionRequest hook (v3)
+// Claude Notifier — PermissionRequest hook
 // Plays a sound + shows a notification when Claude needs permission to use a tool.
 const { isMuted, readConfig } = require("./_lib/config");
 const { resolveSound, BUNDLED_FALLBACK } = require("./_lib/sounds");
@@ -34,7 +34,7 @@ process.stdin.on("end", () => {
     showNotification(`Claude needs permission to use ${tool}.`);
   }
 
-  writeSignal("input");
+  writeSignal("input", input.session_id);
 
   process.exit(0);
 });

--- a/hook/claude-notifier-on-permission.ps1
+++ b/hook/claude-notifier-on-permission.ps1
@@ -1,4 +1,4 @@
-# Claude Notifier - PermissionRequest hook (PowerShell, v3)
+# Claude Notifier - PermissionRequest hook (PowerShell)
 # Plays sound + shows notification when Claude needs permission.
 $ErrorActionPreference = 'SilentlyContinue'
 . (Join-Path $PSScriptRoot '_lib.ps1')
@@ -26,6 +26,6 @@ if ($level -eq 'sound+popup' -or $level -eq 'popup') {
     Show-NotifierNotification -Message "Claude needs permission to use $tool."
 }
 
-Write-NotifierSignal -Reason 'input'
+Write-NotifierSignal -Reason 'input' -SessionId $data.session_id
 
 exit 0

--- a/hook/claude-notifier-on-prompt.js
+++ b/hook/claude-notifier-on-prompt.js
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+// Claude Notifier — UserPromptSubmit hook
+// Signals the extension to advance the per-session stage when the user
+// submits a new prompt. No sound, no notification — coordination only.
+const { writeSignal } = require("./_lib/signal");
+
+let raw = "";
+process.stdin.setEncoding("utf-8");
+process.stdin.on("data", (chunk) => (raw += chunk));
+process.stdin.on("end", () => {
+  let input = {};
+  try { input = JSON.parse(raw); } catch { process.exit(0); }
+  writeSignal("prompt", input.session_id);
+  process.exit(0);
+});

--- a/hook/claude-notifier-on-prompt.ps1
+++ b/hook/claude-notifier-on-prompt.ps1
@@ -1,0 +1,12 @@
+# Claude Notifier - UserPromptSubmit hook (PowerShell)
+# Signals the extension to advance the per-session stage when the user
+# submits a new prompt. No sound, no notification — coordination only.
+$ErrorActionPreference = 'SilentlyContinue'
+. (Join-Path $PSScriptRoot '_lib.ps1')
+
+$raw = [Console]::In.ReadToEnd()
+try { $data = $raw | ConvertFrom-Json } catch { exit 0 }
+
+Write-NotifierSignal -Reason 'prompt' -SessionId $data.session_id
+
+exit 0

--- a/hook/claude-notifier-on-question.js
+++ b/hook/claude-notifier-on-question.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// Claude Notifier — PreToolUse hook for AskUserQuestion (v3)
+// Claude Notifier — PreToolUse hook for AskUserQuestion
 // Plays a sound + shows a notification when Claude asks the user a question.
 const { isMuted, readConfig } = require("./_lib/config");
 const { resolveSound, BUNDLED_FALLBACK } = require("./_lib/sounds");
@@ -33,7 +33,7 @@ process.stdin.on("end", () => {
     showNotification("Claude is asking you a question.");
   }
 
-  writeSignal("question");
+  writeSignal("question", input.session_id);
 
   process.exit(0);
 });

--- a/hook/claude-notifier-on-question.ps1
+++ b/hook/claude-notifier-on-question.ps1
@@ -1,4 +1,4 @@
-# Claude Notifier - PreToolUse hook for AskUserQuestion (PowerShell, v3)
+# Claude Notifier - PreToolUse hook for AskUserQuestion (PowerShell)
 # Plays sound + shows notification when Claude asks the user a question.
 $ErrorActionPreference = 'SilentlyContinue'
 . (Join-Path $PSScriptRoot '_lib.ps1')
@@ -25,6 +25,6 @@ if ($level -eq 'sound+popup' -or $level -eq 'popup') {
     Show-NotifierNotification -Message 'Claude is asking you a question.'
 }
 
-Write-NotifierSignal -Reason 'question'
+Write-NotifierSignal -Reason 'question' -SessionId $data.session_id
 
 exit 0

--- a/hook/claude-notifier-on-stop.js
+++ b/hook/claude-notifier-on-stop.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// Claude Notifier — Stop hook (v4)
+// Claude Notifier — Stop hook
 // Writes a "done" signal for the VSCode extension to debounce. When no
 // extension is active (terminal-only Claude session, or session outside any
 // open workspace), plays sound/notification directly as a fallback.
@@ -22,7 +22,7 @@ process.stdin.on("end", () => {
 
   const cwd = (input && input.cwd) || process.cwd() || "";
 
-  writeSignal("done", cwd);
+  writeSignal("done", input.session_id, cwd);
 
   // If a VSCode window owns this cwd, the extension handles sound/notification
   // with debounce. Otherwise fall through to direct playback.

--- a/hook/claude-notifier-on-stop.ps1
+++ b/hook/claude-notifier-on-stop.ps1
@@ -1,4 +1,4 @@
-# Claude Notifier - Stop hook (PowerShell, v4)
+# Claude Notifier - Stop hook (PowerShell)
 # Writes a "done" signal for the VSCode extension to debounce. When no
 # extension is active (terminal-only), plays sound/notification directly.
 $ErrorActionPreference = 'SilentlyContinue'
@@ -14,7 +14,7 @@ $cwd = ""
 if ($data.cwd) { $cwd = "$($data.cwd)" }
 if (-not $cwd) { $cwd = (Get-Location).Path }
 
-Write-NotifierSignal -Reason 'done' -Cwd $cwd
+Write-NotifierSignal -Reason 'done' -SessionId $data.session_id -Cwd $cwd
 
 # If a VSCode window owns this cwd, the extension handles sound/notification
 # with debounce. Otherwise fall through to direct playback.

--- a/install.sh
+++ b/install.sh
@@ -20,7 +20,7 @@ echo "Installing Claude Notifier..."
 
 mkdir -p "$HOOKS_DIR" "$HOOKS_DIR/_lib"
 
-for script in claude-notifier-on-stop.js claude-notifier-on-permission.js claude-notifier-on-question.js; do
+for script in claude-notifier-on-stop.js claude-notifier-on-permission.js claude-notifier-on-question.js claude-notifier-on-prompt.js; do
   curl -fsSL "$REPO_RAW/hook/$script" -o "$HOOKS_DIR/$script"
   chmod +x "$HOOKS_DIR/$script"
 done
@@ -43,6 +43,7 @@ fi
 STOP_HOOK="$HOOKS_DIR/claude-notifier-on-stop.js"
 PERM_HOOK="$HOOKS_DIR/claude-notifier-on-permission.js"
 QUESTION_HOOK="$HOOKS_DIR/claude-notifier-on-question.js"
+PROMPT_HOOK="$HOOKS_DIR/claude-notifier-on-prompt.js"
 
 node -e "
 const fs = require('fs');
@@ -50,7 +51,7 @@ const settings = JSON.parse(fs.readFileSync('$SETTINGS_FILE', 'utf-8'));
 if (!settings.hooks) settings.hooks = {};
 
 // Clean stale entries from all hook types
-for (const t of ['Stop', 'PermissionRequest', 'PreToolUse', 'Notification']) {
+for (const t of ['Stop', 'PermissionRequest', 'PreToolUse', 'Notification', 'UserPromptSubmit']) {
   if (settings.hooks[t]) {
     settings.hooks[t] = settings.hooks[t].filter(
       e => !e.hooks?.some(h => h.command?.includes('claude-notifier'))
@@ -76,6 +77,12 @@ if (!settings.hooks.PreToolUse) settings.hooks.PreToolUse = [];
 settings.hooks.PreToolUse.push({
   matcher: 'AskUserQuestion',
   hooks: [{ type: 'command', command: 'node \"$QUESTION_HOOK\"' }]
+});
+
+// UserPromptSubmit hook — coordination only, no sound (advances stage dedup)
+if (!settings.hooks.UserPromptSubmit) settings.hooks.UserPromptSubmit = [];
+settings.hooks.UserPromptSubmit.push({
+  hooks: [{ type: 'command', command: 'node \"$PROMPT_HOOK\"' }]
 });
 
 fs.writeFileSync('$SETTINGS_FILE', JSON.stringify(settings, null, 2) + '\n');

--- a/package.json
+++ b/package.json
@@ -88,7 +88,8 @@
           "default": 2000,
           "minimum": 0,
           "maximum": 10000,
-          "description": "Milliseconds to wait after a 'done' signal before notifying. Collapses rapid subtask Stop events into a single notification. Lower = snappier; higher = safer against duplicates."
+          "deprecationMessage": "Deprecated and ignored. Per-session stage dedup replaces it. Safe to delete from your settings.",
+          "description": "Deprecated and ignored. Per-session stage dedup handles rapid 'done' signal coalescing."
         }
       }
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,8 +7,11 @@ import { initDiscovery, installTerminalNotifierFlow } from "./notifications/term
 import { writeOwnPidFile, cleanStalePidFiles } from "./routing/cwd";
 import { startSignalWatcher } from "./signals/dispatch";
 import { createStatusBar, toggleSound } from "./ui/status-bar";
+import { initLogger, log } from "./log";
 
 export function activate(context: vscode.ExtensionContext) {
+  initLogger(context);
+  log("activate: extensionPath=", context.extensionPath);
   setupHooks(context.extensionPath);
   syncConfig();
   initDiscovery();

--- a/src/hooks/lifecycle.ts
+++ b/src/hooks/lifecycle.ts
@@ -137,6 +137,7 @@ export function teardownHooks(): void {
     "claude-notifier-on-permission",
     "claude-notifier-on-question",
     "claude-notifier-on-notification",
+    "claude-notifier-on-prompt",
   ];
   const legacyHookFiles = legacyNames.flatMap((name) =>
     [".js", ".ps1", ".sh"].map((ext) => path.join(HOOKS_DIR, `${name}${ext}`))

--- a/src/hooks/registry.ts
+++ b/src/hooks/registry.ts
@@ -34,6 +34,17 @@ export const HOOKS: HookDef[] = [
     eventKey: "asksQuestion",
     defaultSound: "Funk",
   },
+  {
+    // Coordination-only hook: tells the extension's stage state machine to
+    // advance when the user submits a new prompt. No user-visible behavior
+    // — no sound, no notification, no settings knobs. eventKey/defaultSound
+    // unused for this hook but kept non-empty so generic registry loops
+    // (syncConfig, etc.) don't choke on undefined values.
+    baseName: "claude-notifier-on-prompt",
+    type: "UserPromptSubmit",
+    eventKey: "userPromptSubmit",
+    defaultSound: "",
+  },
 ];
 
 export function hookFileName(hook: HookDef): string {
@@ -45,4 +56,4 @@ export function hookDestPath(hook: HookDef): string {
 }
 
 /** Hook types that may appear in settings.json (used for cleanup). */
-export const ALL_HOOK_TYPES = ["Stop", "PermissionRequest", "PreToolUse", "Notification"] as const;
+export const ALL_HOOK_TYPES = ["Stop", "PermissionRequest", "PreToolUse", "Notification", "UserPromptSubmit"] as const;

--- a/src/log.ts
+++ b/src/log.ts
@@ -1,0 +1,22 @@
+import * as vscode from "vscode";
+
+let channel: vscode.OutputChannel | null = null;
+
+/**
+ * Lazy-init a "Claude Notifier" output channel. Call at extension activate
+ * (passing the context's subscriptions for cleanup), then `log()` anywhere.
+ * No-op if not initialized — extension code paths that might run before
+ * activation stay safe.
+ */
+export function initLogger(context: vscode.ExtensionContext): void {
+  if (channel) return;
+  channel = vscode.window.createOutputChannel("Claude Notifier");
+  context.subscriptions.push(channel);
+}
+
+export function log(...parts: unknown[]): void {
+  if (!channel) return;
+  const ts = new Date().toISOString().slice(11, 23); // HH:MM:SS.mmm
+  const msg = parts.map((p) => (typeof p === "string" ? p : JSON.stringify(p))).join(" ");
+  channel.appendLine(`[${ts}] ${msg}`);
+}

--- a/src/notifications/terminal-notifier.ts
+++ b/src/notifications/terminal-notifier.ts
@@ -8,7 +8,7 @@ import { IS_MAC } from "../paths";
 // focus VS Code instead of Script Editor. We use -execute (not -activate)
 // because -activate is broken on recent macOS, and we run the `code` CLI so
 // the specific workspace window comes forward — no osascript on the click
-// path means no Script Editor flash. See issue #12.
+// path means no Script Editor flash.
 let terminalNotifierPath: string | null = null;
 let codeCliPath: string | null = null;
 
@@ -49,7 +49,7 @@ export function initDiscovery(): void {
 /**
  * Bootstrap: install terminal-notifier via Homebrew so macOS notifications
  * can route clicks back to VS Code. The osascript fallback works without it
- * but its clicks open Script Editor (issue #12).
+ * but its clicks open Script Editor instead.
  */
 export function installTerminalNotifierFlow(): void {
   if (!IS_MAC) {

--- a/src/signals/dispatch.ts
+++ b/src/signals/dispatch.ts
@@ -3,18 +3,20 @@ import * as vscode from "vscode";
 import { SIGNAL_FILE } from "../paths";
 import { LEVELS } from "./types";
 import { parseSignal } from "./parser";
+import * as stage from "./stage";
+import { log } from "../log";
 import { getOwnWorkspaceFolders, cwdMatchesFolder } from "../routing/cwd";
 import { getEventLevel, getEventConfig } from "../settings/sync";
 import { playLocalSound } from "../notifications/sound";
 import { showLocalNotification } from "../notifications/local";
 import { playRemoteSound } from "../notifications/remote";
 
-let doneDebounceTimer: ReturnType<typeof setTimeout> | null = null;
 let watcher: fs.FSWatcher | null = null;
+let deprecationLogged = false;
 
 /**
  * Watch SIGNAL_FILE for changes and route to handleSignal(). Returns a
- * Disposable that closes the watcher.
+ * Disposable that closes the watcher and tears down per-session stage state.
  */
 export function startSignalWatcher(): vscode.Disposable {
   if (!fs.existsSync(SIGNAL_FILE)) {
@@ -25,7 +27,14 @@ export function startSignalWatcher(): vscode.Disposable {
       handleSignal();
     }
   });
-  return { dispose: () => { watcher?.close(); watcher = null; } };
+  log("signal watcher started:", SIGNAL_FILE);
+  return {
+    dispose: () => {
+      watcher?.close();
+      watcher = null;
+      stage.reset();
+    },
+  };
 }
 
 function handleSignal(): void {
@@ -35,12 +44,21 @@ function handleSignal(): void {
   } catch {
     return;
   }
+  if (!content) return;
 
-  const { reason, cwd } = parseSignal(content);
+  const { reason, sessionId, cwd } = parseSignal(content);
+  log("signal:", reason, sessionId ?? "-", cwd || "(no cwd)");
+
+  // UserPromptSubmit is coordination-only — advance the stage and exit.
+  // No cwd routing for prompt; the prompt advance applies to every window
+  // tracking this session (or the anonymous session).
+  if (reason === "prompt") {
+    stage.advance(sessionId);
+    return;
+  }
 
   // Each window only handles signals fired from inside its own workspace.
-  // Signals without a cwd (older hook scripts) fall through to all windows
-  // for backwards compatibility.
+  // Signals without a cwd (older hook scripts, prompt hook) fall through.
   if (cwd) {
     const folders = getOwnWorkspaceFolders();
     if (folders.length > 0 && !folders.some((f) => cwdMatchesFolder(cwd, f))) {
@@ -48,34 +66,40 @@ function handleSignal(): void {
     }
   }
 
-  if (reason === "done") {
-    // Debounce "done" signals — Claude fires Stop hooks between subtasks.
-    // Only notify after N ms of silence (no new signals).
-    const debounceMs = vscode.workspace
-      .getConfiguration("claudeNotifier")
-      .get<number>("doneDebounceMs", 2000);
-    if (doneDebounceTimer) clearTimeout(doneDebounceTimer);
-    doneDebounceTimer = setTimeout(() => {
-      doneDebounceTimer = null;
-      showNotification("done");
-    }, debounceMs);
-  } else {
-    // "question" and "input" signals are immediate — user action is needed.
-    // Cancel any pending "done" notification (the stop after a question is expected).
-    if (doneDebounceTimer) {
-      clearTimeout(doneDebounceTimer);
-      doneDebounceTimer = null;
+  if (reason === "done" || reason === "input" || reason === "question") {
+    // Stage dedup: at most one notification per (session, reason) per stage.
+    // Stage advances on UserPromptSubmit (prompt signal) or idle (30 min).
+    if (!stage.shouldFire(sessionId, reason)) {
+      return;
     }
-    if (reason === "input" || reason === "question") {
-      showNotification(reason);
-    }
+    showNotification(reason);
+  }
+
+  // doneDebounceMs is deprecated — stage dedup replaces it. Log once so
+  // anyone who set the value sees what's going on.
+  warnDeprecatedSettingOnce();
+}
+
+function warnDeprecatedSettingOnce(): void {
+  if (deprecationLogged) return;
+  const raw = vscode.workspace.getConfiguration("claudeNotifier").inspect<number>("doneDebounceMs");
+  const explicit =
+    raw?.globalValue !== undefined ||
+    raw?.workspaceValue !== undefined ||
+    raw?.workspaceFolderValue !== undefined;
+  if (explicit) {
+    log(
+      "[config] claudeNotifier.doneDebounceMs is deprecated and ignored; per-session stage dedup replaces it. Remove the setting to silence this notice."
+    );
+    deprecationLogged = true;
   }
 }
 
 function showNotification(reason: string): void {
   // Architecture note: "question" and "input" local sounds are played by their
   // respective hook scripts (PreToolUse / PermissionRequest) — not the extension.
-  // Only "done" local sounds are played here, because the extension debounces them.
+  // Only "done" local sounds are played here, because the extension is the
+  // only place that can debounce across multiple Stop signals from one task.
   const isRemote = !!vscode.env.remoteName;
 
   if (reason === "input") {

--- a/src/signals/parser.ts
+++ b/src/signals/parser.ts
@@ -1,17 +1,45 @@
 export interface ParsedSignal {
   reason: string;
+  /** Session id from Claude Code; null when absent (older hooks or v1 format). */
+  sessionId: string | null;
   cwd: string;
 }
 
 /**
- * Signal format written by hook scripts:
- *   "<reason> <timestamp> <cwd...>"
- * cwd may contain spaces; older scripts may omit cwd or timestamp entirely.
+ * Signal formats written by hook scripts:
+ *
+ * v2 (current): "<reason> <ts> <session_id|-> <cwd?>"
+ *   session_id is "-" when missing; cwd is optional.
+ *
+ * v1 (legacy): "<reason> <ts> <cwd?>"
+ *   No session_id. Still parsed for hooks deployed by an older extension
+ *   version. The third token disambiguates: if it parses as a base-10
+ *   integer-only timestamp-shape it's v1's cwd-start; if it's a token
+ *   with no path separator and no dot it's v2's session_id. We pick a
+ *   simpler heuristic: a session id is a single token with no path
+ *   separator (/ or \\); a cwd contains a path separator.
+ *
+ * Both formats: cwd may contain spaces and is the rest of the line after
+ * the leading tokens.
  */
 export function parseSignal(content: string): ParsedSignal {
+  const parts = content.split(" ");
+  const reason = parts[0] ?? "";
+  const third = parts[2];
+
+  // v2 detection: third token is "-" or a token without path separators.
+  // v1: third token starts the cwd (which contains / or \\, or is missing).
+  const isV2 = third !== undefined && third !== "" && (third === "-" || (!third.includes("/") && !third.includes("\\")));
+
+  if (isV2) {
+    const sessionId = third === "-" ? null : (third ?? null);
+    const cwd = parts.slice(3).join(" ");
+    return { reason, sessionId, cwd };
+  }
+
+  // v1 fallback: "<reason> <ts> <cwd?>"
   const firstSpace = content.indexOf(" ");
   const secondSpace = firstSpace >= 0 ? content.indexOf(" ", firstSpace + 1) : -1;
-  const reason = firstSpace < 0 ? content : content.slice(0, firstSpace);
   const cwd = secondSpace >= 0 ? content.slice(secondSpace + 1) : "";
-  return { reason, cwd };
+  return { reason, sessionId: null, cwd };
 }

--- a/src/signals/stage.ts
+++ b/src/signals/stage.ts
@@ -1,0 +1,120 @@
+import { log } from "../log";
+
+/**
+ * Per-session stage state machine.
+ *
+ * A "stage" is a logical user-facing task — bounded on one end by a user
+ * prompt (UserPromptSubmit hook) and on the other end by the user's next
+ * prompt or a long idle period.
+ *
+ * Within a stage, at most one notification fires per *reason* (`done`,
+ * `input`, `question`). Subsequent events for the same reason in the same
+ * stage are suppressed.
+ *
+ * Stage advances when:
+ *   - The user submits a new prompt (UserPromptSubmit → primary).
+ *   - A configurable idle window elapses without any signal (fallback for
+ *     sessions that go quiet — e.g., user walked away).
+ *
+ * Session id comes from Claude Code's hook input JSON. When absent (older
+ * hooks or odd input), an "anonymous" sentinel session is used; all
+ * anonymous events share one stage, which is the conservative default.
+ *
+ * State is in-memory only — VS Code restart starts fresh. First event of
+ * every session after restart fires normally.
+ */
+
+const ANON_SESSION = "__anon__";
+
+interface SessionStage {
+  /** Monotonic stage counter for this session. */
+  stageId: number;
+  /** Reasons already fired in the current stage. */
+  fired: Set<string>;
+  /** Last activity timestamp (ms). Used for idle-reset. */
+  lastActivity: number;
+  /** setTimeout handle for the idle reset, or null. */
+  idleTimer: ReturnType<typeof setTimeout> | null;
+}
+
+const sessions = new Map<string, SessionStage>();
+
+/**
+ * Idle window before a stage auto-advances. UserPromptSubmit is the primary
+ * advance trigger; this is the fallback for sessions that go quiet without
+ * a new prompt (e.g., user walked away). 30 min covers most "I came back to
+ * my desk" cases without being so short that mid-task pauses reset.
+ */
+const IDLE_RESET_MS = 30 * 60 * 1000;
+
+function ensure(sid: string): SessionStage {
+  let s = sessions.get(sid);
+  if (!s) {
+    s = { stageId: 0, fired: new Set(), lastActivity: Date.now(), idleTimer: null };
+    sessions.set(sid, s);
+  }
+  return s;
+}
+
+function resolveSessionId(sessionId: string | null | undefined): string {
+  return sessionId && sessionId.length > 0 ? sessionId : ANON_SESSION;
+}
+
+function armIdleTimer(sid: string, s: SessionStage): void {
+  if (s.idleTimer) clearTimeout(s.idleTimer);
+  s.idleTimer = setTimeout(() => {
+    log(`[stage] session ${sid} advanced ${s.stageId}→${s.stageId + 1} (idle ${IDLE_RESET_MS / 60000}m)`);
+    s.stageId += 1;
+    s.fired.clear();
+    s.idleTimer = null;
+  }, IDLE_RESET_MS);
+}
+
+/**
+ * Returns true when the (sessionId, reason) tuple should fire its
+ * notification. Returns false when it should be suppressed (already fired
+ * for this reason in the current stage).
+ *
+ * Side effects: records the fire if returning true; resets the idle timer
+ * either way.
+ */
+export function shouldFire(sessionId: string | null | undefined, reason: string): boolean {
+  const sid = resolveSessionId(sessionId);
+  const s = ensure(sid);
+  s.lastActivity = Date.now();
+  armIdleTimer(sid, s);
+
+  if (s.fired.has(reason)) {
+    log(`[stage] session ${sid} ${reason} suppressed (stage ${s.stageId} already fired)`);
+    return false;
+  }
+  s.fired.add(reason);
+  log(`[stage] session ${sid} ${reason} fired (stage ${s.stageId})`);
+  return true;
+}
+
+/**
+ * Advance the stage for this session. Called on UserPromptSubmit (primary
+ * advance trigger) and from the click-ack path on notifications.
+ */
+export function advance(sessionId: string | null | undefined): void {
+  const sid = resolveSessionId(sessionId);
+  const s = ensure(sid);
+  const from = s.stageId;
+  s.stageId += 1;
+  s.fired.clear();
+  s.lastActivity = Date.now();
+  armIdleTimer(sid, s);
+  log(`[stage] session ${sid} advanced ${from}→${s.stageId} (UserPromptSubmit)`);
+}
+
+/**
+ * Tear down all per-session state. Called on extension deactivate so we
+ * don't leak timers.
+ */
+export function reset(): void {
+  for (const s of sessions.values()) {
+    if (s.idleTimer) clearTimeout(s.idleTimer);
+  }
+  sessions.clear();
+}


### PR DESCRIPTION
## Summary

Replaces the time-window \`doneDebounceMs\` with per-session stage state. Multiple \`done\` / \`input\` / \`question\` events within the same stage coalesce to one notification per reason. Stage advances on \`UserPromptSubmit\` (primary) or after 30 min idle (fallback).

## Signal format v2

\`<reason> <ts> <session_id|-> [cwd]\`

v1 (\`<reason> <ts> [cwd]\`) is still parsed for back-compat with stale hook deployments — disambiguated by a path-separator heuristic on the third token.

## New: \`UserPromptSubmit\` hook

| | |
|---|---|
| Sound | None |
| Notification | None |
| Settings knob | None |
| Role | Writes \`prompt <ts> <session_id>\` so the extension advances the session's stage. |

## New: Output channel

\`View → Output → Claude Notifier\` shows activation, signal receipts, stage transitions, dedup decisions, and config deprecation warnings.

## Deprecation

\`claudeNotifier.doneDebounceMs\` is read but ignored; schema carries a \`deprecationMessage\`. A one-line notice goes to the output channel the first time an explicit value is seen at runtime.

## Files

| File | Change |
|---|---|
| \`hook/claude-notifier-on-prompt.{js,ps1}\` | New — coordination hook |
| \`hook/_lib/signal.js\` + \`hook/_lib.ps1\` | \`writeSignal\` / \`Write-NotifierSignal\` take session_id |
| 4 existing hooks (\`.js\` + \`.ps1\`) | Pass \`input.session_id\` through |
| \`src/log.ts\` | New — output channel logger |
| \`src/signals/stage.ts\` | New — per-session state machine |
| \`src/signals/parser.ts\` | v2 format, v1 fallback via path-separator heuristic |
| \`src/signals/dispatch.ts\` | Consults stage; routes \`prompt\` to \`stage.advance\` |
| \`src/hooks/registry.ts\` | HOOKS gains \`UserPromptSubmit\` entry; \`ALL_HOOK_TYPES\` adds it |
| \`src/hooks/lifecycle.ts\` | Teardown removes prompt hook |
| \`src/extension.ts\` | \`initLogger\` on activate |
| \`install.sh\` | Downloads + registers prompt hook |
| \`package.json\` | \`doneDebounceMs\` marked deprecated |

## Test plan

- [x] Sideload + reload; hook registration includes \`UserPromptSubmit\`.
- [x] Stop/permission/question hooks emit v2 signals (\`<reason> <ts> <session_id|-> [cwd]\`).
- [x] Rapid same-session stops: 1 \`fired\` + N \`suppressed\` in output channel; one OS banner.
- [x] Prompt signal advances stage; next stop fires again.
- [x] Mute short-circuit.
- [x] Config sync.
- [x] Status-bar mute toggle.