### PR TITLE
test: hook script + lib suite (subprocess + direct import)

### DIFF
--- a/package.json
+++ b/package.json
@@ -188,8 +188,9 @@
     "watch": "tsc -watch -p ./",
     "package": "npx @vscode/vsce package",
     "vscode:uninstall": "node ./out/uninstall.js",
-    "test": "npm run test:unit",
-    "test:unit": "vitest run",
+    "test": "npm run test:unit && npm run test:hook",
+    "test:unit": "vitest run test/unit",
+    "test:hook": "vitest run test/hook",
     "test:watch": "vitest",
     "coverage": "vitest run --coverage"
   },

--- a/test/hook/_helpers.ts
+++ b/test/hook/_helpers.ts
@@ -1,0 +1,88 @@
+import { spawnSync } from "child_process";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+
+const HOOK_DIR = path.join(__dirname, "..", "..", "hook");
+
+/** Path to a hook script in the source tree (uses _lib/ in the same dir). */
+export function hookScript(name: string): string {
+  return path.join(HOOK_DIR, `${name}.js`);
+}
+
+/**
+ * Allocate an empty tmp HOME with a .claude/hooks/ scaffold. Caller owns
+ * cleanup via the returned `dispose()` (or vitest's afterEach).
+ */
+export function tmpHome() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "claude-notifier-test-"));
+  const hooksDir = path.join(root, ".claude", "hooks");
+  fs.mkdirSync(hooksDir, { recursive: true });
+  return {
+    root,
+    hooksDir,
+    signalFile: path.join(hooksDir, "claude-signal"),
+    muteFlag: path.join(hooksDir, "claude-notifier-muted"),
+    configFile: path.join(hooksDir, "claude-notifier-config.json"),
+    activeDir: path.join(hooksDir, "claude-notifier-active.d"),
+    dispose() {
+      try { fs.rmSync(root, { recursive: true, force: true }); } catch {}
+    },
+  };
+}
+
+export interface RunResult {
+  status: number | null;
+  stdout: string;
+  stderr: string;
+  durationMs: number;
+}
+
+/**
+ * Run a hook script as a subprocess with synthetic stdin JSON, HOME pointed
+ * at the test sandbox, and PATH stripped so afplay/paplay/notify-send/
+ * osascript can't be found. The hook scripts wrap every spawn in try/catch
+ * with stdio:ignore, so the missing-binary errors are swallowed silently
+ * and the surrounding signal-write path still runs. Tests that explicitly
+ * want sound/notification side effects can pass `keepPath: true`.
+ */
+export function runHook(
+  scriptPath: string,
+  stdin: unknown,
+  home: string,
+  opts: { keepPath?: boolean; extraEnv?: Record<string, string> } = {}
+): RunResult {
+  const started = Date.now();
+  const res = spawnSync(process.execPath, [scriptPath], {
+    input: typeof stdin === "string" ? stdin : JSON.stringify(stdin),
+    env: {
+      ...process.env,
+      HOME: home,
+      PATH: opts.keepPath ? process.env.PATH ?? "" : "/",
+      ...opts.extraEnv,
+    },
+    encoding: "utf-8",
+    timeout: 8_000,
+  });
+  return {
+    status: res.status,
+    stdout: res.stdout ?? "",
+    stderr: res.stderr ?? "",
+    durationMs: Date.now() - started,
+  };
+}
+
+/** Read the signal file or return "" if not present. */
+export function readSignal(signalFile: string): string {
+  try { return fs.readFileSync(signalFile, "utf-8"); } catch { return ""; }
+}
+
+/**
+ * Drop a PID-marker file into the active-extension directory so the on-stop
+ * hook's `extensionOwnsCwd` short-circuits before invoking sound playback.
+ * Uses the test process's own PID (alive while the test runs).
+ */
+export function simulateActiveExtension(activeDir: string, workspaceFolders: string[]): void {
+  fs.mkdirSync(activeDir, { recursive: true });
+  fs.writeFileSync(path.join(activeDir, String(process.pid)), workspaceFolders.join("\n"));
+}

--- a/test/hook/lib.config.test.ts
+++ b/test/hook/lib.config.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from "vitest";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+
+// Set HOME before importing the lib (paths.js binds HOOKS_DIR at module
+// load).
+const HOME_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "claude-notifier-config-"));
+const HOOKS_DIR = path.join(HOME_DIR, ".claude", "hooks");
+const CONFIG_FILE = path.join(HOOKS_DIR, "claude-notifier-config.json");
+const MUTE_FLAG = path.join(HOOKS_DIR, "claude-notifier-muted");
+fs.mkdirSync(HOOKS_DIR, { recursive: true });
+
+const ORIG_HOME = process.env.HOME;
+process.env.HOME = HOME_DIR;
+
+const config = await import("../../hook/_lib/config");
+
+beforeAll(() => {
+  process.env.HOME = HOME_DIR;
+});
+beforeEach(() => {
+  try { fs.unlinkSync(CONFIG_FILE); } catch {}
+  try { fs.unlinkSync(MUTE_FLAG); } catch {}
+});
+afterAll(() => {
+  process.env.HOME = ORIG_HOME;
+  try { fs.rmSync(HOME_DIR, { recursive: true, force: true }); } catch {}
+});
+
+describe("hook/_lib/config — isMuted", () => {
+  it("false when mute flag does not exist", () => {
+    expect(config.isMuted()).toBe(false);
+  });
+
+  it("true when mute flag file exists", () => {
+    fs.writeFileSync(MUTE_FLAG, "");
+    expect(config.isMuted()).toBe(true);
+  });
+});
+
+describe("hook/_lib/config — readConfig", () => {
+  it("returns null when config file does not exist", () => {
+    expect(config.readConfig()).toBeNull();
+  });
+
+  it("returns parsed JSON when config file exists", () => {
+    fs.writeFileSync(
+      CONFIG_FILE,
+      JSON.stringify({ taskCompleted: { level: "sound+popup", sound: "Hero" } })
+    );
+    expect(config.readConfig()).toEqual({
+      taskCompleted: { level: "sound+popup", sound: "Hero" },
+    });
+  });
+
+  it("returns null when config file is malformed JSON", () => {
+    fs.writeFileSync(CONFIG_FILE, "{ not valid json");
+    expect(config.readConfig()).toBeNull();
+  });
+});

--- a/test/hook/lib.signal.test.ts
+++ b/test/hook/lib.signal.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from "vitest";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+
+// Set HOME before importing the lib (paths.js binds HOOKS_DIR at module
+// load, so we must set process.env.HOME first and import once).
+const HOME_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "claude-notifier-signal-"));
+const HOOKS_DIR = path.join(HOME_DIR, ".claude", "hooks");
+const SIGNAL_FILE = path.join(HOOKS_DIR, "claude-signal");
+fs.mkdirSync(HOOKS_DIR, { recursive: true });
+
+const ORIG_HOME = process.env.HOME;
+process.env.HOME = HOME_DIR;
+
+const signal = await import("../../hook/_lib/signal");
+
+beforeAll(() => {
+  process.env.HOME = HOME_DIR;
+});
+beforeEach(() => {
+  try { fs.unlinkSync(SIGNAL_FILE); } catch {}
+});
+afterAll(() => {
+  process.env.HOME = ORIG_HOME;
+  try { fs.rmSync(HOME_DIR, { recursive: true, force: true }); } catch {}
+});
+
+describe("hook/_lib/signal — writeSignal", () => {
+  it("v2 format with session id and cwd", () => {
+    signal.writeSignal("done", "abc-123", "/Users/foo/proj");
+    expect(fs.readFileSync(SIGNAL_FILE, "utf-8")).toMatch(
+      /^done \d+ abc-123 \/Users\/foo\/proj$/
+    );
+  });
+
+  it("v2 format without cwd", () => {
+    signal.writeSignal("input", "abc-123");
+    expect(fs.readFileSync(SIGNAL_FILE, "utf-8")).toMatch(/^input \d+ abc-123$/);
+  });
+
+  it("missing session id renders as '-'", () => {
+    signal.writeSignal("question");
+    expect(fs.readFileSync(SIGNAL_FILE, "utf-8")).toMatch(/^question \d+ -$/);
+  });
+
+  it("empty string session id renders as '-'", () => {
+    signal.writeSignal("done", "", "/cwd");
+    expect(fs.readFileSync(SIGNAL_FILE, "utf-8")).toMatch(/^done \d+ - \/cwd$/);
+  });
+
+  it("session id with whitespace is stripped", () => {
+    signal.writeSignal("done", "abc\t 123\n", "/cwd");
+    expect(fs.readFileSync(SIGNAL_FILE, "utf-8")).toMatch(/^done \d+ abc123 \/cwd$/);
+  });
+
+  it("does not throw with valid args", () => {
+    expect(() => signal.writeSignal("done", "x", "/cwd")).not.toThrow();
+  });
+});

--- a/test/hook/lib.sounds.test.ts
+++ b/test/hook/lib.sounds.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from "vitest";
+import {
+  resolveSound,
+  MACOS_SOUNDS,
+  WIN_SOUNDS,
+  LINUX_SOUNDS,
+  LINUX_SOUNDS_DIR,
+  BUNDLED_SOUNDS_DIR,
+  BUNDLED_FALLBACK,
+} from "../../hook/_lib/sounds";
+
+// resolveSound branches on process.platform (via the hook/_lib/platform
+// module). The test suite runs on whichever host invoked it; we exercise
+// the active-host branch here and validate the cross-platform tables by
+// shape. End-to-end coverage on Win/Linux comes through CI (Phase 7).
+
+describe("hook/_lib/sounds — resolveSound (active platform)", () => {
+  it("returns a known preset's path or falls back to the platform default", () => {
+    const r = resolveSound("Glass", "/mac-default", "C:\\win-default");
+    // One of three valid outcomes depending on the host:
+    expect([
+      MACOS_SOUNDS.Glass,
+      WIN_SOUNDS.Glass ?? "C:\\win-default",
+      LINUX_SOUNDS.Glass,
+    ]).toContain(r);
+  });
+
+  it("unknown preset falls back to the platform-appropriate default", () => {
+    const r = resolveSound("Nonexistent_Preset", "/mac-default", "C:\\win-default");
+    // macOS → defaultMac; Linux → complete.oga; Windows → defaultWin.
+    expect([
+      "/mac-default",
+      "C:\\win-default",
+      `${LINUX_SOUNDS_DIR}/complete.oga`,
+    ]).toContain(r);
+  });
+});
+
+describe("hook/_lib/sounds — cross-platform tables", () => {
+  it("MACOS_SOUNDS covers the 14-preset enum", () => {
+    expect(Object.keys(MACOS_SOUNDS).sort()).toEqual([
+      "Basso", "Blow", "Bottle", "Frog", "Funk", "Glass", "Hero",
+      "Morse", "Ping", "Pop", "Purr", "Sosumi", "Submarine", "Tink",
+    ]);
+    for (const v of Object.values(MACOS_SOUNDS)) {
+      expect(v).toMatch(/^\/System\/Library\/Sounds\/.+\.aiff$/);
+    }
+  });
+
+  it("WIN_SOUNDS covers the 8 Windows presets", () => {
+    expect(Object.keys(WIN_SOUNDS).sort()).toEqual([
+      "Windows Background", "Windows Notify", "chimes", "chord", "ding",
+      "notify", "ringin", "tada",
+    ]);
+    for (const v of Object.values(WIN_SOUNDS)) {
+      expect(v).toMatch(/^C:\\Windows\\Media\\.+\.wav$/);
+    }
+  });
+
+  it("LINUX_SOUNDS mirrors the macOS preset names", () => {
+    // Every macOS preset name has a Linux equivalent so users can pick the
+    // same value cross-platform.
+    for (const name of Object.keys(MACOS_SOUNDS)) {
+      expect(LINUX_SOUNDS[name as keyof typeof LINUX_SOUNDS]).toBeDefined();
+    }
+    for (const v of Object.values(LINUX_SOUNDS)) {
+      expect(v).toContain(LINUX_SOUNDS_DIR);
+      expect(v).toMatch(/\.oga$/);
+    }
+  });
+});
+
+describe("hook/_lib/sounds — BUNDLED_FALLBACK", () => {
+  it("exposes a bundled fallback for each event kind", () => {
+    expect(BUNDLED_FALLBACK.taskCompleted).toMatch(/sounds\/task-complete\.wav$/);
+    expect(BUNDLED_FALLBACK.needsPermission).toMatch(/sounds\/needs-input\.wav$/);
+    expect(BUNDLED_FALLBACK.asksQuestion).toMatch(/sounds\/question\.wav$/);
+  });
+
+  it("BUNDLED_SOUNDS_DIR resolves under hook/_lib/sounds/ (deploy target)", () => {
+    expect(BUNDLED_SOUNDS_DIR.endsWith("/hook/_lib/sounds")).toBe(true);
+  });
+});

--- a/test/hook/on-notification.test.ts
+++ b/test/hook/on-notification.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "fs";
+import { tmpHome, runHook, readSignal, hookScript } from "./_helpers";
+
+const SCRIPT = hookScript("claude-notifier-on-notification");
+
+describe("hook: claude-notifier-on-notification", () => {
+  let home: ReturnType<typeof tmpHome>;
+  beforeEach(() => (home = tmpHome()));
+  afterEach(() => home.dispose());
+
+  it("writes an 'input' signal for permission_prompt", () => {
+    const res = runHook(
+      SCRIPT,
+      { notification_type: "permission_prompt", session_id: "s-1" },
+      home.root
+    );
+    expect(res.status).toBe(0);
+    expect(readSignal(home.signalFile)).toMatch(/^input \d+ s-1$/);
+  });
+
+  it("non-permission_prompt notification_type is ignored", () => {
+    const res = runHook(
+      SCRIPT,
+      { notification_type: "idle", session_id: "s-1" },
+      home.root
+    );
+    expect(res.status).toBe(0);
+    expect(readSignal(home.signalFile)).toBe("");
+  });
+
+  it("missing notification_type exits cleanly", () => {
+    const res = runHook(SCRIPT, { session_id: "s-1" }, home.root);
+    expect(res.status).toBe(0);
+    expect(readSignal(home.signalFile)).toBe("");
+  });
+
+  it("muted: short-circuits before signal", () => {
+    fs.writeFileSync(home.muteFlag, "");
+    const res = runHook(
+      SCRIPT,
+      { notification_type: "permission_prompt", session_id: "s-1" },
+      home.root
+    );
+    expect(res.status).toBe(0);
+    expect(readSignal(home.signalFile)).toBe("");
+    expect(res.durationMs).toBeLessThan(500);
+  });
+
+  it("uses input.message field if provided, otherwise default text", () => {
+    // We can't directly observe the notification text from outside the
+    // subprocess; just verify the hook accepts both shapes and writes
+    // the signal correctly.
+    const res = runHook(
+      SCRIPT,
+      {
+        notification_type: "permission_prompt",
+        session_id: "s-1",
+        message: "Claude says: $(whoami)",
+      },
+      home.root
+    );
+    expect(res.status).toBe(0);
+    expect(readSignal(home.signalFile)).toMatch(/^input \d+ s-1$/);
+  });
+
+  it("malformed JSON exits 0 with no signal", () => {
+    const res = runHook(SCRIPT, "x", home.root);
+    expect(res.status).toBe(0);
+    expect(readSignal(home.signalFile)).toBe("");
+  });
+});

--- a/test/hook/on-permission.test.ts
+++ b/test/hook/on-permission.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "fs";
+import { tmpHome, runHook, readSignal, hookScript } from "./_helpers";
+
+const SCRIPT = hookScript("claude-notifier-on-permission");
+
+// PATH is stripped in runHook so afplay/notify-send/osascript can't be
+// found — the hook's try/catch swallows the spawn failure and the signal
+// write path still runs. This lets us verify the full flow without
+// actually playing sounds during tests.
+
+describe("hook: claude-notifier-on-permission", () => {
+  let home: ReturnType<typeof tmpHome>;
+  beforeEach(() => (home = tmpHome()));
+  afterEach(() => home.dispose());
+
+  it("writes an 'input' signal for a normal tool", () => {
+    const res = runHook(SCRIPT, { tool_name: "Bash", session_id: "s-1" }, home.root);
+    expect(res.status).toBe(0);
+    expect(readSignal(home.signalFile)).toMatch(/^input \d+ s-1$/);
+  });
+
+  it("AskUserQuestion is skipped (handled by the question hook)", () => {
+    const res = runHook(
+      SCRIPT,
+      { tool_name: "AskUserQuestion", session_id: "s-1" },
+      home.root
+    );
+    expect(res.status).toBe(0);
+    expect(readSignal(home.signalFile)).toBe("");
+  });
+
+  it("muted: exits before signal write", () => {
+    fs.writeFileSync(home.muteFlag, "");
+    const res = runHook(SCRIPT, { tool_name: "Bash", session_id: "s-1" }, home.root);
+    expect(res.status).toBe(0);
+    expect(readSignal(home.signalFile)).toBe("");
+    expect(res.durationMs).toBeLessThan(500);
+  });
+
+  it("level=off: exits before signal write", () => {
+    fs.writeFileSync(
+      home.configFile,
+      JSON.stringify({ needsPermission: { level: "off" } })
+    );
+    const res = runHook(SCRIPT, { tool_name: "Bash", session_id: "s-1" }, home.root);
+    expect(res.status).toBe(0);
+    expect(readSignal(home.signalFile)).toBe("");
+  });
+
+  it("renders missing session id as '-'", () => {
+    const res = runHook(SCRIPT, { tool_name: "Bash" }, home.root);
+    expect(res.status).toBe(0);
+    expect(readSignal(home.signalFile)).toMatch(/^input \d+ -$/);
+  });
+
+  it("malformed JSON input exits 0 with no signal", () => {
+    const res = runHook(SCRIPT, "{ broken", home.root);
+    expect(res.status).toBe(0);
+    expect(readSignal(home.signalFile)).toBe("");
+  });
+
+  it("handles a tool name with shell metacharacters in the notification text without crashing", () => {
+    // Regression for the audit-flagged escaping issue. Even though PATH is
+    // stripped so the spawn doesn't run, the hook's string-build path
+    // should not throw on weird input.
+    const res = runHook(
+      SCRIPT,
+      { tool_name: 'Bash; rm -rf /; echo "x', session_id: "s-1" },
+      home.root
+    );
+    expect(res.status).toBe(0);
+    expect(readSignal(home.signalFile)).toMatch(/^input \d+ s-1$/);
+  });
+});

--- a/test/hook/on-prompt.test.ts
+++ b/test/hook/on-prompt.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { tmpHome, runHook, readSignal, hookScript } from "./_helpers";
+
+const SCRIPT = hookScript("claude-notifier-on-prompt");
+
+describe("hook: claude-notifier-on-prompt", () => {
+  let home: ReturnType<typeof tmpHome>;
+  beforeEach(() => (home = tmpHome()));
+  afterEach(() => home.dispose());
+
+  it("writes a 'prompt' signal with session id", () => {
+    const res = runHook(SCRIPT, { session_id: "s-abc" }, home.root);
+    expect(res.status).toBe(0);
+    expect(readSignal(home.signalFile)).toMatch(/^prompt \d+ s-abc$/);
+  });
+
+  it("missing session id renders as '-'", () => {
+    const res = runHook(SCRIPT, {}, home.root);
+    expect(res.status).toBe(0);
+    expect(readSignal(home.signalFile)).toMatch(/^prompt \d+ -$/);
+  });
+
+  it("never plays sound or shows notification (coordination only)", () => {
+    const res = runHook(SCRIPT, { session_id: "s-1" }, home.root);
+    expect(res.status).toBe(0);
+    // No mute flag set, no notification spawn — purely fast.
+    expect(res.durationMs).toBeLessThan(500);
+  });
+
+  it("malformed JSON exits 0 with no signal", () => {
+    const res = runHook(SCRIPT, "[not json", home.root);
+    expect(res.status).toBe(0);
+    expect(readSignal(home.signalFile)).toBe("");
+  });
+
+  it("ignores extra fields", () => {
+    const res = runHook(
+      SCRIPT,
+      { session_id: "s-1", prompt: "hello world", whatever: [1, 2] },
+      home.root
+    );
+    expect(res.status).toBe(0);
+    expect(readSignal(home.signalFile)).toMatch(/^prompt \d+ s-1$/);
+  });
+});

--- a/test/hook/on-question.test.ts
+++ b/test/hook/on-question.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "fs";
+import { tmpHome, runHook, readSignal, hookScript } from "./_helpers";
+
+const SCRIPT = hookScript("claude-notifier-on-question");
+
+describe("hook: claude-notifier-on-question", () => {
+  let home: ReturnType<typeof tmpHome>;
+  beforeEach(() => (home = tmpHome()));
+  afterEach(() => home.dispose());
+
+  it("writes a 'question' signal for AskUserQuestion", () => {
+    const res = runHook(SCRIPT, { tool_name: "AskUserQuestion", session_id: "s-1" }, home.root);
+    expect(res.status).toBe(0);
+    expect(readSignal(home.signalFile)).toMatch(/^question \d+ s-1$/);
+  });
+
+  it("ignores non-AskUserQuestion tools (defense-in-depth against misconfigured matcher)", () => {
+    for (const tool of ["Bash", "Read", "Edit", "Grep"]) {
+      const res = runHook(SCRIPT, { tool_name: tool, session_id: "s-1" }, home.root);
+      expect(res.status).toBe(0);
+      expect(readSignal(home.signalFile)).toBe("");
+    }
+  });
+
+  it("missing tool_name is treated as non-match", () => {
+    const res = runHook(SCRIPT, { session_id: "s-1" }, home.root);
+    expect(res.status).toBe(0);
+    expect(readSignal(home.signalFile)).toBe("");
+  });
+
+  it("muted: exits before signal write", () => {
+    fs.writeFileSync(home.muteFlag, "");
+    const res = runHook(
+      SCRIPT,
+      { tool_name: "AskUserQuestion", session_id: "s-1" },
+      home.root
+    );
+    expect(res.status).toBe(0);
+    expect(readSignal(home.signalFile)).toBe("");
+    expect(res.durationMs).toBeLessThan(500);
+  });
+
+  it("level=off: exits before signal write", () => {
+    fs.writeFileSync(home.configFile, JSON.stringify({ asksQuestion: { level: "off" } }));
+    const res = runHook(
+      SCRIPT,
+      { tool_name: "AskUserQuestion", session_id: "s-1" },
+      home.root
+    );
+    expect(res.status).toBe(0);
+    expect(readSignal(home.signalFile)).toBe("");
+  });
+
+  it("malformed JSON input exits 0 with no signal", () => {
+    const res = runHook(SCRIPT, "garbage", home.root);
+    expect(res.status).toBe(0);
+    expect(readSignal(home.signalFile)).toBe("");
+  });
+
+  it("renders missing session id as '-'", () => {
+    const res = runHook(SCRIPT, { tool_name: "AskUserQuestion" }, home.root);
+    expect(res.status).toBe(0);
+    expect(readSignal(home.signalFile)).toMatch(/^question \d+ -$/);
+  });
+});

--- a/test/hook/on-stop.test.ts
+++ b/test/hook/on-stop.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "fs";
+import { tmpHome, runHook, readSignal, hookScript, simulateActiveExtension } from "./_helpers";
+
+const SCRIPT = hookScript("claude-notifier-on-stop");
+
+describe("hook: claude-notifier-on-stop", () => {
+  let home: ReturnType<typeof tmpHome>;
+
+  beforeEach(() => {
+    home = tmpHome();
+    // Simulate an active extension owning the cwd by default, so the hook
+    // writes its signal and exits cleanly before invoking sound playback.
+    // Tests that explicitly want the terminal-fallback path can override.
+    simulateActiveExtension(home.activeDir, ["/Users/foo/proj"]);
+  });
+  afterEach(() => home.dispose());
+
+  it("writes a v2 'done' signal with session id and cwd", () => {
+    const res = runHook(SCRIPT, { session_id: "s-123", cwd: "/Users/foo/proj" }, home.root);
+    expect(res.status).toBe(0);
+    expect(readSignal(home.signalFile)).toMatch(/^done \d+ s-123 \/Users\/foo\/proj$/);
+  });
+
+  it("renders missing session id as '-'", () => {
+    const res = runHook(SCRIPT, { cwd: "/Users/foo/proj" }, home.root);
+    expect(res.status).toBe(0);
+    expect(readSignal(home.signalFile)).toMatch(/^done \d+ - \/Users\/foo\/proj$/);
+  });
+
+  it("falls back to process.cwd() when input.cwd missing", () => {
+    const res = runHook(SCRIPT, { session_id: "s-1" }, home.root);
+    expect(res.status).toBe(0);
+    expect(readSignal(home.signalFile)).toMatch(/^done \d+ s-1 \S+/);
+  });
+
+  it("stop_hook_active short-circuits before signal write", () => {
+    const res = runHook(
+      SCRIPT,
+      { session_id: "s-1", cwd: "/Users/foo/proj", stop_hook_active: true },
+      home.root
+    );
+    expect(res.status).toBe(0);
+    expect(readSignal(home.signalFile)).toBe("");
+  });
+
+  it("muted: short-circuits before signal write (no sound, no signal)", () => {
+    fs.writeFileSync(home.muteFlag, "");
+    const res = runHook(SCRIPT, { session_id: "s-1", cwd: "/Users/foo/proj" }, home.root);
+    expect(res.status).toBe(0);
+    expect(readSignal(home.signalFile)).toBe("");
+    // Fast exit confirms the sound spawn was never attempted.
+    expect(res.durationMs).toBeLessThan(500);
+  });
+
+  it("malformed JSON input exits 0 with no signal", () => {
+    const res = runHook(SCRIPT, "not valid json", home.root);
+    expect(res.status).toBe(0);
+    expect(readSignal(home.signalFile)).toBe("");
+  });
+
+  it("ignores extra fields in the input JSON", () => {
+    const res = runHook(
+      SCRIPT,
+      {
+        session_id: "s-1",
+        cwd: "/Users/foo/proj",
+        extra: { nested: ["random"] },
+        unknown_field: 42,
+      },
+      home.root
+    );
+    expect(res.status).toBe(0);
+    expect(readSignal(home.signalFile)).toMatch(/^done \d+ s-1 \/Users\/foo\/proj$/);
+  });
+
+  it("cwd outside any active marker's folder falls through (signal still written)", () => {
+    // The marker we placed in beforeEach claims /Users/foo/proj.
+    // /tmp/different is not inside it, so extensionOwnsCwd returns false
+    // and the hook proceeds to terminal-fallback. Signal still gets written.
+    const res = runHook(SCRIPT, { session_id: "s-1", cwd: "/tmp/different" }, home.root);
+    expect(res.status).toBe(0);
+    expect(readSignal(home.signalFile)).toMatch(/^done \d+ s-1 \/tmp\/different$/);
+    // No timing assertion — terminal fallback may play sound here.
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,10 +3,13 @@ import * as path from "path";
 
 export default defineConfig({
   test: {
-    include: ["test/unit/**/*.test.ts"],
+    include: ["test/unit/**/*.test.ts", "test/hook/**/*.test.ts"],
+    // Hook subprocess tests can take several seconds (waiting for sound to
+    // finish or for spawn timeouts); raise the per-test ceiling.
+    testTimeout: 10_000,
     coverage: {
       provider: "v8",
-      include: ["src/**/*.ts"],
+      include: ["src/**/*.ts", "hook/_lib/**/*.js"],
       exclude: ["src/extension.ts", "src/uninstall.ts"],
       reporter: ["text", "html"],
     },


### PR DESCRIPTION
## Summary

Second test layer. Drives each hook script as a Node subprocess with synthetic stdin + tmp HOME sandbox, and exercises the shared \`hook/_lib/*\` modules directly. **51 tests across 8 files, ~935 ms.**

Total project test count is now **108** (57 unit + 51 hook).

## Suite

### Library tests (direct import)

| File | Targets | Tests |
|---|---|---|
| \`test/hook/lib.sounds.test.ts\` | \`resolveSound\` on the active platform; cross-platform table shapes (MACOS_SOUNDS, WIN_SOUNDS, LINUX_SOUNDS); \`BUNDLED_FALLBACK\` paths | 10 |
| \`test/hook/lib.signal.test.ts\` | \`writeSignal\` v2 payload: session id, '-' sentinel, whitespace strip, no-cwd path | 6 |
| \`test/hook/lib.config.test.ts\` | \`isMuted\`, \`readConfig\` (existence, parse, malformed JSON) | 5 |

### Hook script tests (subprocess via \`spawnSync\`)

| File | Targets | Tests |
|---|---|---|
| \`test/hook/on-stop.test.ts\` | Signal payload, \`stop_hook_active\` short-circuit, mute, cwd routing via active-PID marker | 8 |
| \`test/hook/on-permission.test.ts\` | Signal write, AskUserQuestion skip, mute, level=off, shell-metachar tool name | 7 |
| \`test/hook/on-question.test.ts\` | AskUserQuestion-only, defense-in-depth against misconfigured matcher, mute, level=off | 8 |
| \`test/hook/on-notification.test.ts\` | \`notification_type=permission_prompt\` gate, mute, message field | 6 |
| \`test/hook/on-prompt.test.ts\` | Coordination-only (no sound, no notification) | 5 |

## Implementation notes

- **\`test/hook/_helpers.ts\`** — \`runHook(script, stdin, home)\` spawns the hook script with a tmp HOME and \`PATH=/\` so \`afplay\`/\`paplay\`/\`notify-send\`/\`osascript\` spawn failures fall into the hook's existing try/catch. Signal-write paths still run; tests stay quiet and fast. Tests that explicitly want sound can pass \`keepPath: true\`.
- **\`simulateActiveExtension()\`** drops a PID-marker file with the test process's own PID (alive while the test runs) so on-stop's \`extensionOwnsCwd\` short-circuits the terminal-fallback path. Lets us verify signal writes without invoking sound.
- **Lib tests** for signal/config use a single tmp HOME for the whole file, set before the dynamic import that binds \`HOOKS_DIR\` at module load. \`vi.resetModules()\` doesn't reliably re-resolve nested \`require()\`s for paths.js across iterations.

## Scripts

\`\`\`json
\"test\": \"npm run test:unit && npm run test:hook\",
\"test:unit\": \"vitest run test/unit\",
\"test:hook\": \"vitest run test/hook\",
\"test:watch\": \"vitest\",
\"coverage\": \"vitest run --coverage\"
\`\`\`

## Test plan

- [x] \`npm test\` → 108 / 108 pass.
- [x] \`npm run test:hook\` independently — 51 / 51 pass.
- [ ] CI workflow (next PR) runs both suites on Linux + macOS + Windows.
- [ ] PowerShell hook tests — out of scope for this PR (need pwsh on CI; can be added when the Windows runner is wired).