### PR TITLE
chore: lint, format, typecheck, smoke gates

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,10 @@
+node_modules/
+out/
+coverage/
+*.vsix
+*.wav
+package-lock.json
+
+# Prose is hand-formatted; let the author own line wrapping and structure.
+*.md
+LICENSE*

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,8 @@
+{
+  "printWidth": 100,
+  "tabWidth": 2,
+  "semi": true,
+  "singleQuote": false,
+  "trailingComma": "es5",
+  "arrowParens": "always"
+}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,66 @@
+import js from "@eslint/js";
+import tseslint from "typescript-eslint";
+import prettier from "eslint-config-prettier";
+
+export default tseslint.config(
+  {
+    ignores: ["out/**", "node_modules/**", "coverage/**", "*.vsix"],
+  },
+  js.configs.recommended,
+  // TypeScript with type-aware rules — applies only to .ts files in the
+  // tsconfig projects below. .js files (hook scripts) get a looser config
+  // further down.
+  {
+    files: ["src/**/*.ts", "test/**/*.ts"],
+    extends: [...tseslint.configs.recommendedTypeChecked],
+    languageOptions: {
+      parserOptions: {
+        project: ["./tsconfig.json", "./tsconfig.test.json"],
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+    rules: {
+      // Catches forgotten awaits — the main async-bug class strict TS misses.
+      "@typescript-eslint/no-floating-promises": "error",
+      // Async callback passed where sync expected.
+      "@typescript-eslint/no-misused-promises": "error",
+
+      // `settings.hooks?.[type]` etc. work on user-owned freeform JSON; we
+      // type it as `any` deliberately so we don't pretend to validate a
+      // schema we don't own. Disable the cascade of no-unsafe-* rules.
+      "@typescript-eslint/no-explicit-any": "off",
+      "@typescript-eslint/no-unsafe-assignment": "off",
+      "@typescript-eslint/no-unsafe-member-access": "off",
+      "@typescript-eslint/no-unsafe-call": "off",
+      "@typescript-eslint/no-unsafe-argument": "off",
+      "@typescript-eslint/no-unsafe-return": "off",
+
+      "@typescript-eslint/no-unused-vars": ["warn", { argsIgnorePattern: "^_" }],
+      "no-empty": ["error", { allowEmptyCatch: true }],
+      // `let x = ""; try { x = ... } catch { return }` is intentional —
+      // the catch needs the binding declared before the assignment so the
+      // default-then-overwrite pattern is the cleanest way.
+      "no-useless-assignment": "off",
+    },
+  },
+  // Hook .js files — plain Node, no TypeScript project. Lint with the
+  // non-type-aware base rules.
+  {
+    files: ["hook/**/*.js"],
+    extends: [tseslint.configs.disableTypeChecked],
+    languageOptions: {
+      globals: {
+        process: "readonly",
+        require: "readonly",
+        module: "writable",
+        __dirname: "readonly",
+        Buffer: "readonly",
+      },
+    },
+    rules: {
+      "no-empty": ["error", { allowEmptyCatch: true }],
+      "no-unused-vars": ["warn", { argsIgnorePattern: "^_" }],
+    },
+  },
+  prettier
+);

--- a/hook/_lib/active.js
+++ b/hook/_lib/active.js
@@ -19,15 +19,28 @@ function cwdInsideFolder(cwd, folder) {
  */
 function extensionOwnsCwd(cwd) {
   let entries;
-  try { entries = fs.readdirSync(ACTIVE_DIR); } catch { return false; }
+  try {
+    entries = fs.readdirSync(ACTIVE_DIR);
+  } catch {
+    return false;
+  }
   for (const name of entries) {
     const pid = parseInt(name, 10);
     if (!Number.isFinite(pid)) continue;
-    try { process.kill(pid, 0); } catch { continue; }
+    try {
+      process.kill(pid, 0);
+    } catch {
+      continue;
+    }
     let folders = "";
-    try { folders = fs.readFileSync(path.join(ACTIVE_DIR, name), "utf-8"); } catch {}
+    try {
+      folders = fs.readFileSync(path.join(ACTIVE_DIR, name), "utf-8");
+    } catch {}
     if (!folders.trim()) return true;
-    for (const folder of folders.split("\n").map((s) => s.trim()).filter(Boolean)) {
+    for (const folder of folders
+      .split("\n")
+      .map((s) => s.trim())
+      .filter(Boolean)) {
       if (cwdInsideFolder(cwd, folder)) return true;
     }
   }

--- a/hook/_lib/config.js
+++ b/hook/_lib/config.js
@@ -2,8 +2,11 @@ const fs = require("fs");
 const { CONFIG_FILE, MUTE_FLAG } = require("./paths");
 
 function readConfig() {
-  try { return JSON.parse(fs.readFileSync(CONFIG_FILE, "utf-8")); }
-  catch { return null; }
+  try {
+    return JSON.parse(fs.readFileSync(CONFIG_FILE, "utf-8"));
+  } catch {
+    return null;
+  }
 }
 
 function isMuted() {

--- a/hook/_lib/notify.js
+++ b/hook/_lib/notify.js
@@ -17,7 +17,10 @@ function appleScriptEscape(s) {
 function findTerminalNotifier() {
   if (!IS_MAC) return null;
   for (const c of ["/opt/homebrew/bin/terminal-notifier", "/usr/local/bin/terminal-notifier"]) {
-    try { fs.accessSync(c, fs.constants.X_OK); return c; } catch {}
+    try {
+      fs.accessSync(c, fs.constants.X_OK);
+      return c;
+    } catch {}
   }
   try {
     const out = execFileSync("/usr/bin/which", ["terminal-notifier"], { encoding: "utf-8" }).trim();
@@ -41,10 +44,16 @@ function showNotification(message, opts = {}) {
       const safeMsg = psSingleQuoteEscape(message);
       const safeTitle = psSingleQuoteEscape(TITLE);
       const ps = `Add-Type -AssemblyName System.Windows.Forms; $n=New-Object System.Windows.Forms.NotifyIcon; $n.Icon=[System.Drawing.SystemIcons]::Information; $n.Visible=$true; $n.ShowBalloonTip(3000,'${safeTitle}','${safeMsg}',[System.Windows.Forms.ToolTipIcon]::None); Start-Sleep -m 500; $n.Dispose()`;
-      execSync(`${PS_BIN} -NoProfile -NonInteractive -EncodedCommand ${Buffer.from(ps, "utf16le").toString("base64")}`, { stdio: "ignore", timeout: 5000 });
+      execSync(
+        `${PS_BIN} -NoProfile -NonInteractive -EncodedCommand ${Buffer.from(ps, "utf16le").toString("base64")}`,
+        { stdio: "ignore", timeout: 5000 }
+      );
     } else if (IS_LINUX) {
       // execFileSync bypasses the shell — no shell-escaping concerns for $ or `.
-      execFileSync("notify-send", ["--app-name=Claude Code", TITLE, String(message)], { stdio: "ignore", timeout: 5000 });
+      execFileSync("notify-send", ["--app-name=Claude Code", TITLE, String(message)], {
+        stdio: "ignore",
+        timeout: 5000,
+      });
     } else if (IS_MAC) {
       if (preferTn) {
         const tn = findTerminalNotifier();
@@ -55,7 +64,9 @@ function showNotification(message, opts = {}) {
       }
       // execFileSync bypasses the shell; AppleScript still needs its own \ and " escaping.
       const escaped = appleScriptEscape(message);
-      execFileSync("osascript", ["-e", `display notification "${escaped}" with title "${TITLE}"`], { stdio: "ignore" });
+      execFileSync("osascript", ["-e", `display notification "${escaped}" with title "${TITLE}"`], {
+        stdio: "ignore",
+      });
     }
   } catch {}
 }

--- a/hook/_lib/platform.js
+++ b/hook/_lib/platform.js
@@ -1,9 +1,16 @@
 const fs = require("fs");
 
 const IS_WIN = process.platform === "win32";
-const IS_WSL = !IS_WIN && process.platform === "linux" && (() => {
-  try { return fs.readFileSync("/proc/version", "utf-8").toLowerCase().includes("microsoft"); } catch { return false; }
-})();
+const IS_WSL =
+  !IS_WIN &&
+  process.platform === "linux" &&
+  (() => {
+    try {
+      return fs.readFileSync("/proc/version", "utf-8").toLowerCase().includes("microsoft");
+    } catch {
+      return false;
+    }
+  })();
 const USE_WIN = IS_WIN || IS_WSL;
 const PS_BIN = IS_WSL ? "powershell.exe" : "powershell";
 const IS_LINUX = !IS_WIN && !IS_WSL && process.platform === "linux";

--- a/hook/_lib/play.js
+++ b/hook/_lib/play.js
@@ -12,17 +12,22 @@ const { USE_WIN, IS_LINUX, PS_BIN } = require("./platform");
  *   cross-platform misconfig, removed system sounds, etc.
  */
 function playSound(primaryPath, fallbackPath) {
-  const soundPath = (primaryPath && fs.existsSync(primaryPath))
-    ? primaryPath
-    : (fallbackPath || primaryPath);
+  const soundPath =
+    primaryPath && fs.existsSync(primaryPath) ? primaryPath : fallbackPath || primaryPath;
   if (!soundPath) return;
   try {
     if (USE_WIN) {
       const ps = `$s='${soundPath}'; if(Test-Path $s){(New-Object Media.SoundPlayer $s).PlaySync()}else{[console]::Beep(800,300)}`;
-      execSync(`${PS_BIN} -NoProfile -NonInteractive -EncodedCommand ${Buffer.from(ps, "utf16le").toString("base64")}`, { stdio: "ignore", timeout: 5000 });
+      execSync(
+        `${PS_BIN} -NoProfile -NonInteractive -EncodedCommand ${Buffer.from(ps, "utf16le").toString("base64")}`,
+        { stdio: "ignore", timeout: 5000 }
+      );
     } else if (IS_LINUX) {
       // paplay (PulseAudio/PipeWire) preferred; aplay (ALSA) as fallback.
-      execSync(`paplay "${soundPath}" 2>/dev/null || aplay "${soundPath}" 2>/dev/null`, { stdio: "ignore", timeout: 5000 });
+      execSync(`paplay "${soundPath}" 2>/dev/null || aplay "${soundPath}" 2>/dev/null`, {
+        stdio: "ignore",
+        timeout: 5000,
+      });
     } else {
       execSync(`afplay "${soundPath}"`, { stdio: "ignore" });
     }

--- a/hook/_lib/signal.js
+++ b/hook/_lib/signal.js
@@ -20,9 +20,7 @@ function writeSignal(reason, sessionId, cwd) {
     // parseable. Empty/missing → "-".
     const sid = sessionId ? String(sessionId).replace(/\s+/g, "") : "-";
     const safeSid = sid || "-";
-    const payload = cwd
-      ? `${reason} ${ts} ${safeSid} ${cwd}`
-      : `${reason} ${ts} ${safeSid}`;
+    const payload = cwd ? `${reason} ${ts} ${safeSid} ${cwd}` : `${reason} ${ts} ${safeSid}`;
     fs.writeFileSync(SIGNAL_FILE, payload);
   } catch {}
 }

--- a/hook/_lib/sounds.js
+++ b/hook/_lib/sounds.js
@@ -8,45 +8,55 @@ const { USE_WIN, IS_LINUX } = require("./platform");
 // presets are still the default; this is purely a resilience fallback.
 const BUNDLED_SOUNDS_DIR = path.join(__dirname, "sounds");
 const BUNDLED_FALLBACK = {
-  taskCompleted:   path.join(BUNDLED_SOUNDS_DIR, "task-complete.wav"),
+  taskCompleted: path.join(BUNDLED_SOUNDS_DIR, "task-complete.wav"),
   needsPermission: path.join(BUNDLED_SOUNDS_DIR, "needs-input.wav"),
-  asksQuestion:    path.join(BUNDLED_SOUNDS_DIR, "question.wav"),
+  asksQuestion: path.join(BUNDLED_SOUNDS_DIR, "question.wav"),
 };
 
-
 const MACOS_SOUNDS = {
-  Basso: "/System/Library/Sounds/Basso.aiff", Blow: "/System/Library/Sounds/Blow.aiff",
-  Bottle: "/System/Library/Sounds/Bottle.aiff", Frog: "/System/Library/Sounds/Frog.aiff",
-  Funk: "/System/Library/Sounds/Funk.aiff", Glass: "/System/Library/Sounds/Glass.aiff",
-  Hero: "/System/Library/Sounds/Hero.aiff", Morse: "/System/Library/Sounds/Morse.aiff",
-  Ping: "/System/Library/Sounds/Ping.aiff", Pop: "/System/Library/Sounds/Pop.aiff",
-  Purr: "/System/Library/Sounds/Purr.aiff", Sosumi: "/System/Library/Sounds/Sosumi.aiff",
-  Submarine: "/System/Library/Sounds/Submarine.aiff", Tink: "/System/Library/Sounds/Tink.aiff",
+  Basso: "/System/Library/Sounds/Basso.aiff",
+  Blow: "/System/Library/Sounds/Blow.aiff",
+  Bottle: "/System/Library/Sounds/Bottle.aiff",
+  Frog: "/System/Library/Sounds/Frog.aiff",
+  Funk: "/System/Library/Sounds/Funk.aiff",
+  Glass: "/System/Library/Sounds/Glass.aiff",
+  Hero: "/System/Library/Sounds/Hero.aiff",
+  Morse: "/System/Library/Sounds/Morse.aiff",
+  Ping: "/System/Library/Sounds/Ping.aiff",
+  Pop: "/System/Library/Sounds/Pop.aiff",
+  Purr: "/System/Library/Sounds/Purr.aiff",
+  Sosumi: "/System/Library/Sounds/Sosumi.aiff",
+  Submarine: "/System/Library/Sounds/Submarine.aiff",
+  Tink: "/System/Library/Sounds/Tink.aiff",
 };
 
 const WIN_SOUNDS = {
-  "Windows Notify": "C:\\Windows\\Media\\Windows Notify.wav", "tada": "C:\\Windows\\Media\\tada.wav",
-  "chimes": "C:\\Windows\\Media\\chimes.wav", "chord": "C:\\Windows\\Media\\chord.wav",
-  "ding": "C:\\Windows\\Media\\ding.wav", "notify": "C:\\Windows\\Media\\notify.wav",
-  "ringin": "C:\\Windows\\Media\\ringin.wav", "Windows Background": "C:\\Windows\\Media\\Windows Background.wav",
+  "Windows Notify": "C:\\Windows\\Media\\Windows Notify.wav",
+  tada: "C:\\Windows\\Media\\tada.wav",
+  chimes: "C:\\Windows\\Media\\chimes.wav",
+  chord: "C:\\Windows\\Media\\chord.wav",
+  ding: "C:\\Windows\\Media\\ding.wav",
+  notify: "C:\\Windows\\Media\\notify.wav",
+  ringin: "C:\\Windows\\Media\\ringin.wav",
+  "Windows Background": "C:\\Windows\\Media\\Windows Background.wav",
 };
 
 const LINUX_SOUNDS_DIR = "/usr/share/sounds/freedesktop/stereo";
 const LINUX_SOUNDS = {
-  Basso:     `${LINUX_SOUNDS_DIR}/dialog-warning.oga`,
-  Blow:      `${LINUX_SOUNDS_DIR}/service-logout.oga`,
-  Bottle:    `${LINUX_SOUNDS_DIR}/bell.oga`,
-  Frog:      `${LINUX_SOUNDS_DIR}/message-new-instant.oga`,
-  Funk:      `${LINUX_SOUNDS_DIR}/message-new-instant.oga`,
-  Glass:     `${LINUX_SOUNDS_DIR}/bell.oga`,
-  Hero:      `${LINUX_SOUNDS_DIR}/complete.oga`,
-  Morse:     `${LINUX_SOUNDS_DIR}/message.oga`,
-  Ping:      `${LINUX_SOUNDS_DIR}/message.oga`,
-  Pop:       `${LINUX_SOUNDS_DIR}/dialog-information.oga`,
-  Purr:      `${LINUX_SOUNDS_DIR}/service-login.oga`,
-  Sosumi:    `${LINUX_SOUNDS_DIR}/dialog-warning.oga`,
+  Basso: `${LINUX_SOUNDS_DIR}/dialog-warning.oga`,
+  Blow: `${LINUX_SOUNDS_DIR}/service-logout.oga`,
+  Bottle: `${LINUX_SOUNDS_DIR}/bell.oga`,
+  Frog: `${LINUX_SOUNDS_DIR}/message-new-instant.oga`,
+  Funk: `${LINUX_SOUNDS_DIR}/message-new-instant.oga`,
+  Glass: `${LINUX_SOUNDS_DIR}/bell.oga`,
+  Hero: `${LINUX_SOUNDS_DIR}/complete.oga`,
+  Morse: `${LINUX_SOUNDS_DIR}/message.oga`,
+  Ping: `${LINUX_SOUNDS_DIR}/message.oga`,
+  Pop: `${LINUX_SOUNDS_DIR}/dialog-information.oga`,
+  Purr: `${LINUX_SOUNDS_DIR}/service-login.oga`,
+  Sosumi: `${LINUX_SOUNDS_DIR}/dialog-warning.oga`,
   Submarine: `${LINUX_SOUNDS_DIR}/alarm-clock-elapsed.oga`,
-  Tink:      `${LINUX_SOUNDS_DIR}/bell.oga`,
+  Tink: `${LINUX_SOUNDS_DIR}/bell.oga`,
 };
 
 /**
@@ -60,7 +70,11 @@ function resolveSound(name, defaultMac, defaultWin) {
 }
 
 module.exports = {
-  MACOS_SOUNDS, WIN_SOUNDS, LINUX_SOUNDS, LINUX_SOUNDS_DIR,
-  BUNDLED_SOUNDS_DIR, BUNDLED_FALLBACK,
+  MACOS_SOUNDS,
+  WIN_SOUNDS,
+  LINUX_SOUNDS,
+  LINUX_SOUNDS_DIR,
+  BUNDLED_SOUNDS_DIR,
+  BUNDLED_FALLBACK,
   resolveSound,
 };

--- a/hook/claude-notifier-on-notification.js
+++ b/hook/claude-notifier-on-notification.js
@@ -14,14 +14,22 @@ process.stdin.setEncoding("utf-8");
 process.stdin.on("data", (chunk) => (raw += chunk));
 process.stdin.on("end", () => {
   let input = {};
-  try { input = JSON.parse(raw); } catch { process.exit(0); }
+  try {
+    input = JSON.parse(raw);
+  } catch {
+    process.exit(0);
+  }
 
   if (input.notification_type !== "permission_prompt") process.exit(0);
   if (isMuted()) process.exit(0);
 
   // Fixed sound mapping (Glass on macOS, Notify on Windows, freedesktop bell
   // on Linux — resolveSound's table happens to map "Glass" to all three).
-  const sound = resolveSound("Glass", "/System/Library/Sounds/Glass.aiff", "C:\\Windows\\Media\\Windows Notify.wav");
+  const sound = resolveSound(
+    "Glass",
+    "/System/Library/Sounds/Glass.aiff",
+    "C:\\Windows\\Media\\Windows Notify.wav"
+  );
   playSound(sound, BUNDLED_FALLBACK.needsPermission);
 
   const message = input.message || "Claude needs your permission.";

--- a/hook/claude-notifier-on-permission.js
+++ b/hook/claude-notifier-on-permission.js
@@ -12,7 +12,11 @@ process.stdin.setEncoding("utf-8");
 process.stdin.on("data", (chunk) => (raw += chunk));
 process.stdin.on("end", () => {
   let input = {};
-  try { input = JSON.parse(raw); } catch { process.exit(0); }
+  try {
+    input = JSON.parse(raw);
+  } catch {
+    process.exit(0);
+  }
 
   if (isMuted()) process.exit(0);
 
@@ -25,7 +29,11 @@ process.stdin.on("end", () => {
   if (level === "off") process.exit(0);
 
   if (level === "sound+popup" || level === "sound") {
-    const sound = resolveSound(cfg.sound, "/System/Library/Sounds/Glass.aiff", "C:\\Windows\\Media\\Windows Notify.wav");
+    const sound = resolveSound(
+      cfg.sound,
+      "/System/Library/Sounds/Glass.aiff",
+      "C:\\Windows\\Media\\Windows Notify.wav"
+    );
     playSound(sound, BUNDLED_FALLBACK.needsPermission);
   }
 

--- a/hook/claude-notifier-on-prompt.js
+++ b/hook/claude-notifier-on-prompt.js
@@ -9,7 +9,11 @@ process.stdin.setEncoding("utf-8");
 process.stdin.on("data", (chunk) => (raw += chunk));
 process.stdin.on("end", () => {
   let input = {};
-  try { input = JSON.parse(raw); } catch { process.exit(0); }
+  try {
+    input = JSON.parse(raw);
+  } catch {
+    process.exit(0);
+  }
   writeSignal("prompt", input.session_id);
   process.exit(0);
 });

--- a/hook/claude-notifier-on-question.js
+++ b/hook/claude-notifier-on-question.js
@@ -12,7 +12,11 @@ process.stdin.setEncoding("utf-8");
 process.stdin.on("data", (chunk) => (raw += chunk));
 process.stdin.on("end", () => {
   let input = {};
-  try { input = JSON.parse(raw); } catch { process.exit(0); }
+  try {
+    input = JSON.parse(raw);
+  } catch {
+    process.exit(0);
+  }
 
   // Defense-in-depth: bail if a misconfigured matcher routes other tools here.
   if (input.tool_name !== "AskUserQuestion") process.exit(0);
@@ -25,7 +29,11 @@ process.stdin.on("end", () => {
   if (level === "off") process.exit(0);
 
   if (level === "sound+popup" || level === "sound") {
-    const sound = resolveSound(cfg.sound, "/System/Library/Sounds/Funk.aiff", "C:\\Windows\\Media\\Windows Notify.wav");
+    const sound = resolveSound(
+      cfg.sound,
+      "/System/Library/Sounds/Funk.aiff",
+      "C:\\Windows\\Media\\Windows Notify.wav"
+    );
     playSound(sound, BUNDLED_FALLBACK.asksQuestion);
   }
 

--- a/hook/claude-notifier-on-stop.js
+++ b/hook/claude-notifier-on-stop.js
@@ -15,7 +15,11 @@ process.stdin.setEncoding("utf-8");
 process.stdin.on("data", (chunk) => (raw += chunk));
 process.stdin.on("end", () => {
   let input = {};
-  try { input = JSON.parse(raw); } catch { process.exit(0); }
+  try {
+    input = JSON.parse(raw);
+  } catch {
+    process.exit(0);
+  }
 
   if (input.stop_hook_active) process.exit(0);
   if (isMuted()) process.exit(0);
@@ -34,7 +38,11 @@ process.stdin.on("end", () => {
   if (level === "off") process.exit(0);
 
   if (level === "sound+popup" || level === "sound") {
-    const sound = resolveSound(cfg.sound, "/System/Library/Sounds/Hero.aiff", "C:\\Windows\\Media\\tada.wav");
+    const sound = resolveSound(
+      cfg.sound,
+      "/System/Library/Sounds/Hero.aiff",
+      "C:\\Windows\\Media\\tada.wav"
+    );
     playSound(sound, BUNDLED_FALLBACK.taskCompleted);
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,15 @@
       "name": "claude-notifier",
       "version": "2.4.0",
       "devDependencies": {
+        "@eslint/js": "^10.0.1",
         "@types/node": "^20.0.0",
         "@types/vscode": "^1.85.0",
         "@vitest/coverage-v8": "^4.1.6",
+        "eslint": "^10.4.0",
+        "eslint-config-prettier": "^10.1.8",
+        "prettier": "^3.8.3",
         "typescript": "^5.3.0",
+        "typescript-eslint": "^8.59.3",
         "vitest": "^4.1.6"
       },
       "engines": {
@@ -110,6 +115,200 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.23.5",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
+      "integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^3.0.5",
+        "debug": "^4.3.1",
+        "minimatch": "^10.2.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.6.0.tgz",
+      "integrity": "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.2.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
+      "integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
+      "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "eslint": "^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
+      "integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.1.tgz",
+      "integrity": "sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.2.1",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
       }
     },
     "node_modules/@jridgewell/resolve-uri": {
@@ -487,10 +686,24 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/esrecurse": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+      "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
     },
@@ -510,6 +723,236 @@
       "integrity": "sha512-0Pf95rnwEIwDbmXGC08r0B4TQhAbsHQ5UyTIgVgoieDe4cOnf92usuR5dEczb6bTKEp7ziZH4TV1TRGPPCExtw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.3.tgz",
+      "integrity": "sha512-PwFvSKsXGShKGW6n5bZOhGHEcCZXM8HofLK9fNsEwZXzFRjoY+XT1Vsf1zgyXdwTr0ZYz1/2tkZ0DBTT9jZjhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.59.3",
+        "@typescript-eslint/type-utils": "8.59.3",
+        "@typescript-eslint/utils": "8.59.3",
+        "@typescript-eslint/visitor-keys": "8.59.3",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.59.3",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.3.tgz",
+      "integrity": "sha512-HPwA+hVkfcriajbNvTmZv4VRauibay+cWArYUYq7u7W7PmGShMxbPxLvrwDme55a6d5alG3nrYfhyJ/G28XlLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.59.3",
+        "@typescript-eslint/types": "8.59.3",
+        "@typescript-eslint/typescript-estree": "8.59.3",
+        "@typescript-eslint/visitor-keys": "8.59.3",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.3.tgz",
+      "integrity": "sha512-ECiUWa/KYRGDFUqTNehaRgzDshnJfkTABJxVemHk4ko22gcr0ukloKjWvyQ64g8YCV/UI47kN1dbmjf/GaQYng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.59.3",
+        "@typescript-eslint/types": "^8.59.3",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.3.tgz",
+      "integrity": "sha512-t2LvZnoEfzKtnPjgeEu41xw5gxq9mQVfYy4OoZ4Vlt0sk3JwxmhCca/AR7DwOiHrjWgjAj6as4AhRLKSDfvZIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.59.3",
+        "@typescript-eslint/visitor-keys": "8.59.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.3.tgz",
+      "integrity": "sha512-PcIJHjmaREXLgIAIzLnSY9VucEzz8FKXsRgFa1DmdGCK/5tJpW03TKJF01Q6VZd1lLdz2sIKPWaDUZN9dp//dw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.3.tgz",
+      "integrity": "sha512-g71d8QD8UaiHGvrJwyIS1hCX5r63w6Jll+4VEYhEAHXTDIqX1JgxhTAbEHtKntL9kuc4jRo7/GWw5xfCepSccQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.59.3",
+        "@typescript-eslint/typescript-estree": "8.59.3",
+        "@typescript-eslint/utils": "8.59.3",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.3.tgz",
+      "integrity": "sha512-ePFoH0g4ludssdRFqqDxQePCxU4WQyRa9+XVwjm7yLn0FKhMeoetC+qBEEI1Eyb1pGSDveTIT09Bvw2WhlGayg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.3.tgz",
+      "integrity": "sha512-CbRjVRAf7Lr9Kr8RopKcbY45p2VfmmHrm0ygOCYFi7oU8q19m0Fs/6iHS7kNOmwpp+ob07ZVcAqlxUod9lYdmg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.59.3",
+        "@typescript-eslint/tsconfig-utils": "8.59.3",
+        "@typescript-eslint/types": "8.59.3",
+        "@typescript-eslint/visitor-keys": "8.59.3",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.3.tgz",
+      "integrity": "sha512-JAvT14goBzRzzzZyqq3P9BLArIxTtQURUtFgQ/V7FO+eU+Gg6ES+5ymOPP1wRxXcxAYeivCk4uS3jCKWI1K8Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.59.3",
+        "@typescript-eslint/types": "8.59.3",
+        "@typescript-eslint/typescript-estree": "8.59.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.3.tgz",
+      "integrity": "sha512-f1UQF7ggd42YiwI5wGrRaPsa+P0CINBlrkLPmGfpq/u/I/oVtecoEIfFR9ag/oa1sLOsRNZ6xehf6qMZhQGBDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.59.3",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
     },
     "node_modules/@vitest/coverage-v8": {
       "version": "4.1.6",
@@ -655,6 +1098,46 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -677,6 +1160,29 @@
         "js-tokens": "^10.0.0"
       }
     },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
     "node_modules/chai": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -691,6 +1197,46 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -711,6 +1257,177 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.4.0.tgz",
+      "integrity": "sha512-loXy6bWOoP3EP6JA7jo6p5jMpBJmHmsNZM5SFRHLdh1MGOPurMnNBj4ZlAbaqUAaQWbCr7jHV4P7gzAyryZWkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@eslint/config-array": "^0.23.5",
+        "@eslint/config-helpers": "^0.6.0",
+        "@eslint/core": "^1.2.1",
+        "@eslint/plugin-kit": "^0.7.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^9.1.2",
+        "eslint-visitor-keys": "^5.0.1",
+        "espree": "^11.2.0",
+        "esquery": "^1.7.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "minimatch": "^10.2.4",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "10.1.8",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
+      "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-config-prettier"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
+      "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@types/esrecurse": "^4.3.1",
+        "@types/estree": "^1.0.8",
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^5.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -719,6 +1436,16 @@
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/expect-type": {
@@ -730,6 +1457,27 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -749,6 +1497,57 @@
         }
       }
     },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -762,6 +1561,19 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/has-flag": {
@@ -780,6 +1592,56 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
@@ -826,6 +1688,51 @@
       "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
     },
     "node_modules/lightningcss": {
       "version": "1.32.0",
@@ -1100,6 +2007,22 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -1138,6 +2061,29 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/nanoid": {
       "version": "3.3.12",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
@@ -1157,6 +2103,13 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/obug": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
@@ -1167,6 +2120,76 @@
         "https://opencollective.com/debug"
       ],
       "license": "MIT"
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/pathe": {
       "version": "2.0.3",
@@ -1224,6 +2247,42 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/rolldown": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.1.tgz",
@@ -1269,6 +2328,29 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/siginfo": {
@@ -1359,6 +2441,19 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -1366,6 +2461,19 @@
       "dev": true,
       "license": "0BSD",
       "optional": true
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
     },
     "node_modules/typescript": {
       "version": "5.9.3",
@@ -1381,12 +2489,46 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/typescript-eslint": {
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.59.3.tgz",
+      "integrity": "sha512-KgusgyDgG4LI8Ih/sWaCtZ06tckLAS5CvT5A4D1Q7bYVoAAyzwiZvE4BmwDHkhRVkvhRBepKeASoFzQetha7Fg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.59.3",
+        "@typescript-eslint/parser": "8.59.3",
+        "@typescript-eslint/typescript-estree": "8.59.3",
+        "@typescript-eslint/utils": "8.59.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
     "node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
     },
     "node_modules/vite": {
       "version": "8.0.13",
@@ -1556,6 +2698,22 @@
         }
       }
     },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -1571,6 +2729,29 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -192,13 +192,24 @@
     "test:unit": "vitest run test/unit",
     "test:hook": "vitest run test/hook",
     "test:watch": "vitest",
-    "coverage": "vitest run --coverage"
+    "coverage": "vitest run --coverage",
+    "typecheck": "tsc -p ./ --noEmit",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
+    "format": "prettier --write .",
+    "format:check": "prettier --check .",
+    "smoke": "bash scripts/smoke.sh"
   },
   "devDependencies": {
+    "@eslint/js": "^10.0.1",
     "@types/node": "^20.0.0",
     "@types/vscode": "^1.85.0",
     "@vitest/coverage-v8": "^4.1.6",
+    "eslint": "^10.4.0",
+    "eslint-config-prettier": "^10.1.8",
+    "prettier": "^3.8.3",
     "typescript": "^5.3.0",
+    "typescript-eslint": "^8.59.3",
     "vitest": "^4.1.6"
   }
 }

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Agent-less pre-release sanity check. Builds the .vsix, drives each hook
+# script with synthetic stdin in a throwaway HOME, and asserts the signal
+# file content. Fails fast on any regression.
+#
+# Usage: npm run smoke
+set -euo pipefail
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO"
+
+red()    { printf '\033[31m%s\033[0m\n' "$*"; }
+green()  { printf '\033[32m%s\033[0m\n' "$*"; }
+yellow() { printf '\033[33m%s\033[0m\n' "$*"; }
+
+step() { yellow "→ $*"; }
+pass() { green  "  ✓ $*"; }
+fail() { red    "  ✗ $*"; exit 1; }
+
+# 1. Compile + package
+step "Building .vsix"
+npm run compile > /dev/null
+npm run package > /tmp/smoke-package.log 2>&1 || { cat /tmp/smoke-package.log; fail "vsce package failed"; }
+VSIX="$(ls -t claude-notifier-*.vsix | head -1)"
+[[ -f "$VSIX" ]] || fail ".vsix not produced"
+pass "$VSIX produced"
+
+# 2. Verify .vsix contents
+step "Inspecting .vsix payload"
+unzip -l "$VSIX" > /tmp/smoke-vsix.txt
+for required in \
+  "extension/package.json" \
+  "extension/out/extension.js" \
+  "extension/hook/claude-notifier-on-stop.js" \
+  "extension/hook/claude-notifier-on-permission.js" \
+  "extension/hook/claude-notifier-on-question.js" \
+  "extension/hook/claude-notifier-on-prompt.js" \
+  "extension/hook/_lib/sounds.js" \
+  "extension/media/sounds/task-complete.wav"
+do
+  grep -qF "$required" /tmp/smoke-vsix.txt || fail "missing from .vsix: $required"
+done
+pass ".vsix contains all required files"
+
+# 3. Drive hook scripts in a throwaway HOME
+step "Smoke-testing hook scripts in a sandboxed HOME"
+TMPHOME="$(mktemp -d -t claude-notifier-smoke-XXXXXX)"
+trap 'rm -rf "$TMPHOME"' EXIT
+mkdir -p "$TMPHOME/.claude/hooks"
+
+# Absolute node path so the subprocess can still be launched after we
+# scrub PATH (which suppresses afplay/paplay/notify-send/etc. in the hook
+# itself — their failures land in the hook's try/catch and the signal
+# write path still runs).
+NODE_BIN="$(command -v node)"
+[[ -x "$NODE_BIN" ]] || fail "node not on PATH"
+
+run_hook() {
+  local name="$1" stdin="$2"
+  echo "$stdin" | HOME="$TMPHOME" PATH=/ "$NODE_BIN" "$REPO/hook/$name.js"
+}
+
+# Stop: expect "done <ts> <sid> <cwd>"
+> "$TMPHOME/.claude/hooks/claude-signal"
+run_hook claude-notifier-on-stop '{"session_id":"smoke","cwd":"/tmp/x"}'
+sig="$(cat "$TMPHOME/.claude/hooks/claude-signal" 2>/dev/null || echo '')"
+[[ "$sig" =~ ^done\ [0-9]+\ smoke\ /tmp/x$ ]] || fail "stop signal wrong: $sig"
+pass "stop hook: $sig"
+
+# Permission: expect "input <ts> <sid>"
+> "$TMPHOME/.claude/hooks/claude-signal"
+run_hook claude-notifier-on-permission '{"tool_name":"Bash","session_id":"smoke"}'
+sig="$(cat "$TMPHOME/.claude/hooks/claude-signal" 2>/dev/null || echo '')"
+[[ "$sig" =~ ^input\ [0-9]+\ smoke$ ]] || fail "permission signal wrong: $sig"
+pass "permission hook: $sig"
+
+# Permission with AskUserQuestion → must skip
+> "$TMPHOME/.claude/hooks/claude-signal"
+run_hook claude-notifier-on-permission '{"tool_name":"AskUserQuestion","session_id":"smoke"}'
+sig="$(cat "$TMPHOME/.claude/hooks/claude-signal" 2>/dev/null || echo '')"
+[[ -z "$sig" ]] || fail "permission should skip AskUserQuestion (got: $sig)"
+pass "permission skips AskUserQuestion"
+
+# Question: expect "question <ts> <sid>"
+> "$TMPHOME/.claude/hooks/claude-signal"
+run_hook claude-notifier-on-question '{"tool_name":"AskUserQuestion","session_id":"smoke"}'
+sig="$(cat "$TMPHOME/.claude/hooks/claude-signal" 2>/dev/null || echo '')"
+[[ "$sig" =~ ^question\ [0-9]+\ smoke$ ]] || fail "question signal wrong: $sig"
+pass "question hook: $sig"
+
+# Prompt: expect "prompt <ts> <sid>"
+> "$TMPHOME/.claude/hooks/claude-signal"
+run_hook claude-notifier-on-prompt '{"session_id":"smoke"}'
+sig="$(cat "$TMPHOME/.claude/hooks/claude-signal" 2>/dev/null || echo '')"
+[[ "$sig" =~ ^prompt\ [0-9]+\ smoke$ ]] || fail "prompt signal wrong: $sig"
+pass "prompt hook: $sig"
+
+# Mute: stop hook should not write signal
+touch "$TMPHOME/.claude/hooks/claude-notifier-muted"
+> "$TMPHOME/.claude/hooks/claude-signal"
+run_hook claude-notifier-on-stop '{"session_id":"smoke","cwd":"/tmp/x"}'
+sig="$(cat "$TMPHOME/.claude/hooks/claude-signal" 2>/dev/null || echo '')"
+[[ -z "$sig" ]] || fail "mute should short-circuit (got: $sig)"
+pass "mute short-circuits"
+
+echo
+green "Smoke check passed."

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -28,15 +28,16 @@ export function activate(context: vscode.ExtensionContext) {
   } catch {}
 
   // Workspace folder set can change at runtime — keep PID file fresh.
-  context.subscriptions.push(
-    vscode.workspace.onDidChangeWorkspaceFolders(() => writeOwnPidFile())
-  );
+  context.subscriptions.push(vscode.workspace.onDidChangeWorkspaceFolders(() => writeOwnPidFile()));
 
   createStatusBar(context);
 
   context.subscriptions.push(
     vscode.commands.registerCommand("claudeNotifier.toggleSound", toggleSound),
-    vscode.commands.registerCommand("claudeNotifier.installTerminalNotifier", installTerminalNotifierFlow),
+    vscode.commands.registerCommand(
+      "claudeNotifier.installTerminalNotifier",
+      installTerminalNotifierFlow
+    ),
     vscode.workspace.onDidChangeConfiguration((e) => {
       if (e.affectsConfiguration("claudeNotifier")) {
         syncConfig();
@@ -51,5 +52,7 @@ export function deactivate() {
   // entries in place so Claude Code outside VS Code (terminal, desktop app)
   // still gets sound + notification via the hook's terminal-fallback path.
   // Full teardown happens on extension uninstall via uninstall.ts.
-  try { fs.unlinkSync(OWN_PID_FILE); } catch {}
+  try {
+    fs.unlinkSync(OWN_PID_FILE);
+  } catch {}
 }

--- a/src/hooks/lifecycle.ts
+++ b/src/hooks/lifecycle.ts
@@ -1,8 +1,6 @@
 import * as fs from "fs";
 import * as path from "path";
-import {
-  HOOKS_DIR, SIGNAL_FILE, MUTE_FLAG, CONFIG_FILE, ACTIVE_DIR, IS_WIN,
-} from "../paths";
+import { HOOKS_DIR, SIGNAL_FILE, MUTE_FLAG, CONFIG_FILE, ACTIVE_DIR, IS_WIN } from "../paths";
 import { HOOKS, hookDestPath } from "./registry";
 import { hookCmd } from "./cmd";
 import { readSettings, writeSettings, stripClaudeNotifierHooks } from "../settings/claude";
@@ -31,7 +29,9 @@ export function setupHooks(extensionPath: string): void {
     const dest = hookDestPath(hook);
     const srcContent = fs.readFileSync(src, "utf-8");
     let destContent = "";
-    try { destContent = fs.readFileSync(dest, "utf-8"); } catch {}
+    try {
+      destContent = fs.readFileSync(dest, "utf-8");
+    } catch {}
     if (srcContent !== destContent) {
       fs.writeFileSync(dest, srcContent, { mode: 0o755 });
     }
@@ -40,9 +40,12 @@ export function setupHooks(extensionPath: string): void {
   // Check if our hooks are already configured with the right runner — skip if so
   const settings = readSettings();
   const hasHook = (type: string, needle: string, matcher?: string) =>
-    settings.hooks?.[type]?.some((entry: any) =>
-      (matcher === undefined || entry.matcher === matcher) &&
-      entry.hooks?.some((h: any) => h.command?.includes(needle) && h.command?.startsWith(HOOK_RUNNER_PREFIX))
+    settings.hooks?.[type]?.some(
+      (entry: any) =>
+        (matcher === undefined || entry.matcher === matcher) &&
+        entry.hooks?.some(
+          (h: any) => h.command?.includes(needle) && h.command?.startsWith(HOOK_RUNNER_PREFIX)
+        )
     );
 
   const allConfigured = HOOKS.every((hook) => hasHook(hook.type, hook.baseName, hook.matcher));
@@ -78,10 +81,7 @@ function copyHookLib(extensionPath: string): void {
   copyBundledSounds(extensionPath);
 
   if (IS_WIN) {
-    syncFile(
-      path.join(extensionPath, "hook", "_lib.ps1"),
-      path.join(HOOKS_DIR, "_lib.ps1")
-    );
+    syncFile(path.join(extensionPath, "hook", "_lib.ps1"), path.join(HOOKS_DIR, "_lib.ps1"));
     return;
   }
   const libSrcDir = path.join(extensionPath, "hook", "_lib");
@@ -98,7 +98,11 @@ function copyBundledSounds(extensionPath: string): void {
   const destDir = path.join(HOOKS_DIR, "_lib", "sounds");
   fs.mkdirSync(destDir, { recursive: true });
   let entries: string[] = [];
-  try { entries = fs.readdirSync(srcDir); } catch { return; }
+  try {
+    entries = fs.readdirSync(srcDir);
+  } catch {
+    return;
+  }
   for (const entry of entries) {
     if (!entry.endsWith(".wav")) continue;
     syncBinaryFile(path.join(srcDir, entry), path.join(destDir, entry));
@@ -110,7 +114,9 @@ function syncBinaryFile(src: string, dest: string): void {
   // Compares byte-for-byte to avoid rewriting unchanged WAVs.
   const srcContent = fs.readFileSync(src);
   let destContent: Buffer | null = null;
-  try { destContent = fs.readFileSync(dest); } catch {}
+  try {
+    destContent = fs.readFileSync(dest);
+  } catch {}
   if (!destContent || !srcContent.equals(destContent)) {
     fs.writeFileSync(dest, srcContent);
   }
@@ -119,7 +125,9 @@ function syncBinaryFile(src: string, dest: string): void {
 function syncFile(src: string, dest: string): void {
   const srcContent = fs.readFileSync(src, "utf-8");
   let destContent = "";
-  try { destContent = fs.readFileSync(dest, "utf-8"); } catch {}
+  try {
+    destContent = fs.readFileSync(dest, "utf-8");
+  } catch {}
   if (srcContent !== destContent) {
     fs.writeFileSync(dest, srcContent);
   }
@@ -153,24 +161,34 @@ export function teardownHooks(): void {
   ];
 
   for (const file of filesToRemove) {
-    try { fs.unlinkSync(file); } catch {}
+    try {
+      fs.unlinkSync(file);
+    } catch {}
   }
 
   // Per-PID active markers directory
   try {
     for (const name of fs.readdirSync(ACTIVE_DIR)) {
-      try { fs.unlinkSync(path.join(ACTIVE_DIR, name)); } catch {}
+      try {
+        fs.unlinkSync(path.join(ACTIVE_DIR, name));
+      } catch {}
     }
     fs.rmdirSync(ACTIVE_DIR);
   } catch {}
 
   // Shared hook library: _lib/*.js + _lib/sounds/*.wav (mac/linux/wsl) and
   // _lib.ps1 (win). Recursive remove handles the nested sounds/ directory.
-  try { fs.unlinkSync(path.join(HOOKS_DIR, "_lib.ps1")); } catch {}
-  try { fs.rmSync(path.join(HOOKS_DIR, "_lib"), { recursive: true, force: true }); } catch {}
+  try {
+    fs.unlinkSync(path.join(HOOKS_DIR, "_lib.ps1"));
+  } catch {}
+  try {
+    fs.rmSync(path.join(HOOKS_DIR, "_lib"), { recursive: true, force: true });
+  } catch {}
 
   // Older versions shipped a generated AppleScript shim — remove if present.
-  try { fs.rmSync(path.join(HOOKS_DIR, "ClaudeNotifier.app"), { recursive: true, force: true }); } catch {}
+  try {
+    fs.rmSync(path.join(HOOKS_DIR, "ClaudeNotifier.app"), { recursive: true, force: true });
+  } catch {}
 
   const settings = readSettings();
   stripClaudeNotifierHooks(settings);

--- a/src/hooks/registry.ts
+++ b/src/hooks/registry.ts
@@ -56,4 +56,10 @@ export function hookDestPath(hook: HookDef): string {
 }
 
 /** Hook types that may appear in settings.json (used for cleanup). */
-export const ALL_HOOK_TYPES = ["Stop", "PermissionRequest", "PreToolUse", "Notification", "UserPromptSubmit"] as const;
+export const ALL_HOOK_TYPES = [
+  "Stop",
+  "PermissionRequest",
+  "PreToolUse",
+  "Notification",
+  "UserPromptSubmit",
+] as const;

--- a/src/notifications/local.ts
+++ b/src/notifications/local.ts
@@ -11,19 +11,19 @@ export function showLocalNotification(message: string): void {
   if (IS_WIN) {
     const safeMsg = message.replace(/'/g, "''");
     const ps = `Add-Type -AssemblyName System.Windows.Forms; $n=New-Object System.Windows.Forms.NotifyIcon; $n.Icon=[System.Drawing.SystemIcons]::Information; $n.Visible=$true; $n.ShowBalloonTip(3000,'Claude Notifier','${safeMsg}',[System.Windows.Forms.ToolTipIcon]::None); Start-Sleep -m 500; $n.Dispose()`;
-    exec(`powershell -NoProfile -NonInteractive -EncodedCommand ${Buffer.from(ps, "utf16le").toString("base64")}`, { timeout: 5000 });
+    exec(
+      `powershell -NoProfile -NonInteractive -EncodedCommand ${Buffer.from(ps, "utf16le").toString("base64")}`,
+      { timeout: 5000 }
+    );
   } else if (IS_MAC && getTerminalNotifierPath()) {
     const tn = getTerminalNotifierPath()!;
     const folder = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath ?? "";
     const codeCli = getCodeCliPath();
-    const executeCmd = codeCli && folder
-      ? `${shellQuote(codeCli)} ${shellQuote(folder)}`
-      : `osascript -e 'tell application "Visual Studio Code" to activate'`;
-    const args = [
-      "-title", "Claude Notifier",
-      "-message", message,
-      "-execute", executeCmd,
-    ];
+    const executeCmd =
+      codeCli && folder
+        ? `${shellQuote(codeCli)} ${shellQuote(folder)}`
+        : `osascript -e 'tell application "Visual Studio Code" to activate'`;
+    const args = ["-title", "Claude Notifier", "-message", message, "-execute", executeCmd];
     exec(`${shellQuote(tn)} ${args.map(shellQuote).join(" ")}`);
   } else {
     const safeMsg = message.replace(/[\\"]/g, "\\$&");

--- a/src/notifications/sound.ts
+++ b/src/notifications/sound.ts
@@ -2,27 +2,41 @@ import { exec } from "child_process";
 import { IS_WIN } from "../paths";
 
 export const MACOS_SOUNDS: Record<string, string> = {
-  Basso: "/System/Library/Sounds/Basso.aiff", Blow: "/System/Library/Sounds/Blow.aiff",
-  Bottle: "/System/Library/Sounds/Bottle.aiff", Frog: "/System/Library/Sounds/Frog.aiff",
-  Funk: "/System/Library/Sounds/Funk.aiff", Glass: "/System/Library/Sounds/Glass.aiff",
-  Hero: "/System/Library/Sounds/Hero.aiff", Morse: "/System/Library/Sounds/Morse.aiff",
-  Ping: "/System/Library/Sounds/Ping.aiff", Pop: "/System/Library/Sounds/Pop.aiff",
-  Purr: "/System/Library/Sounds/Purr.aiff", Sosumi: "/System/Library/Sounds/Sosumi.aiff",
-  Submarine: "/System/Library/Sounds/Submarine.aiff", Tink: "/System/Library/Sounds/Tink.aiff",
+  Basso: "/System/Library/Sounds/Basso.aiff",
+  Blow: "/System/Library/Sounds/Blow.aiff",
+  Bottle: "/System/Library/Sounds/Bottle.aiff",
+  Frog: "/System/Library/Sounds/Frog.aiff",
+  Funk: "/System/Library/Sounds/Funk.aiff",
+  Glass: "/System/Library/Sounds/Glass.aiff",
+  Hero: "/System/Library/Sounds/Hero.aiff",
+  Morse: "/System/Library/Sounds/Morse.aiff",
+  Ping: "/System/Library/Sounds/Ping.aiff",
+  Pop: "/System/Library/Sounds/Pop.aiff",
+  Purr: "/System/Library/Sounds/Purr.aiff",
+  Sosumi: "/System/Library/Sounds/Sosumi.aiff",
+  Submarine: "/System/Library/Sounds/Submarine.aiff",
+  Tink: "/System/Library/Sounds/Tink.aiff",
 };
 
 export const WIN_SOUNDS: Record<string, string> = {
-  "Windows Notify": "C:\\Windows\\Media\\Windows Notify.wav", "tada": "C:\\Windows\\Media\\tada.wav",
-  "chimes": "C:\\Windows\\Media\\chimes.wav", "chord": "C:\\Windows\\Media\\chord.wav",
-  "ding": "C:\\Windows\\Media\\ding.wav", "notify": "C:\\Windows\\Media\\notify.wav",
-  "ringin": "C:\\Windows\\Media\\ringin.wav", "Windows Background": "C:\\Windows\\Media\\Windows Background.wav",
+  "Windows Notify": "C:\\Windows\\Media\\Windows Notify.wav",
+  tada: "C:\\Windows\\Media\\tada.wav",
+  chimes: "C:\\Windows\\Media\\chimes.wav",
+  chord: "C:\\Windows\\Media\\chord.wav",
+  ding: "C:\\Windows\\Media\\ding.wav",
+  notify: "C:\\Windows\\Media\\notify.wav",
+  ringin: "C:\\Windows\\Media\\ringin.wav",
+  "Windows Background": "C:\\Windows\\Media\\Windows Background.wav",
 };
 
 export function playLocalSound(soundName: string, defaultMac: string, defaultWin: string): void {
   if (IS_WIN) {
     const soundPath = WIN_SOUNDS[soundName] || defaultWin;
     const ps = `$s='${soundPath}'; if(Test-Path $s){(New-Object Media.SoundPlayer $s).PlaySync()}else{[console]::Beep(800,300)}`;
-    exec(`powershell -NoProfile -NonInteractive -EncodedCommand ${Buffer.from(ps, "utf16le").toString("base64")}`, { timeout: 5000 });
+    exec(
+      `powershell -NoProfile -NonInteractive -EncodedCommand ${Buffer.from(ps, "utf16le").toString("base64")}`,
+      { timeout: 5000 }
+    );
   } else {
     const soundPath = MACOS_SOUNDS[soundName] || defaultMac;
     exec(`afplay "${soundPath}"`);

--- a/src/notifications/terminal-notifier.ts
+++ b/src/notifications/terminal-notifier.ts
@@ -22,11 +22,19 @@ export function getCodeCliPath(): string | null {
 
 export function findTerminalNotifier(): string | null {
   if (!IS_MAC) return null;
-  for (const candidate of ["/opt/homebrew/bin/terminal-notifier", "/usr/local/bin/terminal-notifier"]) {
-    try { fs.accessSync(candidate, fs.constants.X_OK); return candidate; } catch {}
+  for (const candidate of [
+    "/opt/homebrew/bin/terminal-notifier",
+    "/usr/local/bin/terminal-notifier",
+  ]) {
+    try {
+      fs.accessSync(candidate, fs.constants.X_OK);
+      return candidate;
+    } catch {}
   }
   try {
-    const found = execFileSync("/usr/bin/which", ["terminal-notifier"], { encoding: "utf-8" }).trim();
+    const found = execFileSync("/usr/bin/which", ["terminal-notifier"], {
+      encoding: "utf-8",
+    }).trim();
     if (found) return found;
   } catch {}
   return null;
@@ -37,7 +45,9 @@ export function findCodeCli(): string | null {
     const candidate = path.join(vscode.env.appRoot, "bin", "code");
     fs.accessSync(candidate, fs.constants.X_OK);
     return candidate;
-  } catch { return null; }
+  } catch {
+    return null;
+  }
 }
 
 /** Discover terminal-notifier and code CLI on activation. */
@@ -64,20 +74,29 @@ export function installTerminalNotifierFlow(): void {
   }
   let brew: string | null = null;
   for (const c of ["/opt/homebrew/bin/brew", "/usr/local/bin/brew"]) {
-    try { fs.accessSync(c, fs.constants.X_OK); brew = c; break; } catch {}
+    try {
+      fs.accessSync(c, fs.constants.X_OK);
+      brew = c;
+      break;
+    } catch {}
   }
   if (!brew) {
-    vscode.window.showWarningMessage(
-      "Homebrew not found. Install Homebrew first (https://brew.sh), then re-run this command.",
-      "Open brew.sh"
-    ).then((pick) => {
-      if (pick === "Open brew.sh") vscode.env.openExternal(vscode.Uri.parse("https://brew.sh"));
-    });
+    vscode.window
+      .showWarningMessage(
+        "Homebrew not found. Install Homebrew first (https://brew.sh), then re-run this command.",
+        "Open brew.sh"
+      )
+      .then((pick) => {
+        if (pick === "Open brew.sh") vscode.env.openExternal(vscode.Uri.parse("https://brew.sh"));
+      });
     return;
   }
   // Run interactively in a terminal so the user sees output and any prompts.
-  const terminal = vscode.window.createTerminal({ name: "Claude Notifier — install terminal-notifier" });
+  const terminal = vscode.window.createTerminal({
+    name: "Claude Notifier — install terminal-notifier",
+  });
   terminal.show();
-  terminal.sendText(`${brew} install terminal-notifier && echo "" && echo "✓ Done. Run 'Developer: Reload Window' to enable clickable notifications."`);
+  terminal.sendText(
+    `${brew} install terminal-notifier && echo "" && echo "✓ Done. Run 'Developer: Reload Window' to enable clickable notifications."`
+  );
 }
-

--- a/src/routing/cwd.ts
+++ b/src/routing/cwd.ts
@@ -4,7 +4,12 @@ import * as vscode from "vscode";
 import { ACTIVE_DIR, OWN_PID_FILE } from "../paths";
 
 export function isPidAlive(pid: number): boolean {
-  try { process.kill(pid, 0); return true; } catch { return false; }
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 export function getOwnWorkspaceFolders(): string[] {
@@ -29,7 +34,9 @@ export function cleanStalePidFiles(): void {
     for (const name of fs.readdirSync(ACTIVE_DIR)) {
       const pid = parseInt(name, 10);
       if (!Number.isFinite(pid) || !isPidAlive(pid)) {
-        try { fs.unlinkSync(path.join(ACTIVE_DIR, name)); } catch {}
+        try {
+          fs.unlinkSync(path.join(ACTIVE_DIR, name));
+        } catch {}
       }
     }
   } catch {}

--- a/src/signals/dispatch.ts
+++ b/src/signals/dispatch.ts
@@ -125,7 +125,11 @@ function showNotification(reason: string): void {
         playRemoteSound();
       } else {
         const cfg = getEventConfig("taskCompleted");
-        playLocalSound(cfg.sound, "/System/Library/Sounds/Hero.aiff", "C:\\Windows\\Media\\tada.wav");
+        playLocalSound(
+          cfg.sound,
+          "/System/Library/Sounds/Hero.aiff",
+          "C:\\Windows\\Media\\tada.wav"
+        );
       }
     }
     if (level === LEVELS.SOUND_POPUP || level === LEVELS.POPUP) {

--- a/src/signals/parser.ts
+++ b/src/signals/parser.ts
@@ -29,7 +29,10 @@ export function parseSignal(content: string): ParsedSignal {
 
   // v2 detection: third token is "-" or a token without path separators.
   // v1: third token starts the cwd (which contains / or \\, or is missing).
-  const isV2 = third !== undefined && third !== "" && (third === "-" || (!third.includes("/") && !third.includes("\\")));
+  const isV2 =
+    third !== undefined &&
+    third !== "" &&
+    (third === "-" || (!third.includes("/") && !third.includes("\\")));
 
   if (isV2) {
     const sessionId = third === "-" ? null : (third ?? null);

--- a/src/signals/stage.ts
+++ b/src/signals/stage.ts
@@ -63,7 +63,9 @@ function resolveSessionId(sessionId: string | null | undefined): string {
 function armIdleTimer(sid: string, s: SessionStage): void {
   if (s.idleTimer) clearTimeout(s.idleTimer);
   s.idleTimer = setTimeout(() => {
-    log(`[stage] session ${sid} advanced ${s.stageId}→${s.stageId + 1} (idle ${IDLE_RESET_MS / 60000}m)`);
+    log(
+      `[stage] session ${sid} advanced ${s.stageId}→${s.stageId + 1} (idle ${IDLE_RESET_MS / 60000}m)`
+    );
     s.stageId += 1;
     s.fired.clear();
     s.idleTimer = null;

--- a/src/signals/types.ts
+++ b/src/signals/types.ts
@@ -5,6 +5,6 @@ export const LEVELS = {
   OFF: "off",
 } as const;
 
-export type Level = typeof LEVELS[keyof typeof LEVELS];
+export type Level = (typeof LEVELS)[keyof typeof LEVELS];
 
 export type SignalReason = "input" | "question" | "done";

--- a/src/ui/status-bar.ts
+++ b/src/ui/status-bar.ts
@@ -8,10 +8,7 @@ let soundEnabled = true;
 export function createStatusBar(context: vscode.ExtensionContext): void {
   soundEnabled = !fs.existsSync(MUTE_FLAG);
 
-  statusBarItem = vscode.window.createStatusBarItem(
-    vscode.StatusBarAlignment.Right,
-    100
-  );
+  statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 100);
   statusBarItem.command = "claudeNotifier.toggleSound";
   updateStatusBar();
   statusBarItem.show();
@@ -21,14 +18,14 @@ export function createStatusBar(context: vscode.ExtensionContext): void {
 export function toggleSound(): void {
   soundEnabled = !soundEnabled;
   if (soundEnabled) {
-    try { fs.unlinkSync(MUTE_FLAG); } catch {}
+    try {
+      fs.unlinkSync(MUTE_FLAG);
+    } catch {}
   } else {
     fs.writeFileSync(MUTE_FLAG, "");
   }
   updateStatusBar();
-  vscode.window.showInformationMessage(
-    `Claude Notifier sound: ${soundEnabled ? "ON" : "OFF"}`
-  );
+  vscode.window.showInformationMessage(`Claude Notifier sound: ${soundEnabled ? "ON" : "OFF"}`);
 }
 
 function updateStatusBar(): void {

--- a/test/hook/_helpers.ts
+++ b/test/hook/_helpers.ts
@@ -26,7 +26,9 @@ export function tmpHome() {
     configFile: path.join(hooksDir, "claude-notifier-config.json"),
     activeDir: path.join(hooksDir, "claude-notifier-active.d"),
     dispose() {
-      try { fs.rmSync(root, { recursive: true, force: true }); } catch {}
+      try {
+        fs.rmSync(root, { recursive: true, force: true });
+      } catch {}
     },
   };
 }
@@ -58,7 +60,7 @@ export function runHook(
     env: {
       ...process.env,
       HOME: home,
-      PATH: opts.keepPath ? process.env.PATH ?? "" : "/",
+      PATH: opts.keepPath ? (process.env.PATH ?? "") : "/",
       ...opts.extraEnv,
     },
     encoding: "utf-8",
@@ -74,7 +76,11 @@ export function runHook(
 
 /** Read the signal file or return "" if not present. */
 export function readSignal(signalFile: string): string {
-  try { return fs.readFileSync(signalFile, "utf-8"); } catch { return ""; }
+  try {
+    return fs.readFileSync(signalFile, "utf-8");
+  } catch {
+    return "";
+  }
 }
 
 /**

--- a/test/hook/lib.config.test.ts
+++ b/test/hook/lib.config.test.ts
@@ -20,12 +20,18 @@ beforeAll(() => {
   process.env.HOME = HOME_DIR;
 });
 beforeEach(() => {
-  try { fs.unlinkSync(CONFIG_FILE); } catch {}
-  try { fs.unlinkSync(MUTE_FLAG); } catch {}
+  try {
+    fs.unlinkSync(CONFIG_FILE);
+  } catch {}
+  try {
+    fs.unlinkSync(MUTE_FLAG);
+  } catch {}
 });
 afterAll(() => {
   process.env.HOME = ORIG_HOME;
-  try { fs.rmSync(HOME_DIR, { recursive: true, force: true }); } catch {}
+  try {
+    fs.rmSync(HOME_DIR, { recursive: true, force: true });
+  } catch {}
 });
 
 describe("hook/_lib/config — isMuted", () => {

--- a/test/hook/lib.signal.test.ts
+++ b/test/hook/lib.signal.test.ts
@@ -19,19 +19,21 @@ beforeAll(() => {
   process.env.HOME = HOME_DIR;
 });
 beforeEach(() => {
-  try { fs.unlinkSync(SIGNAL_FILE); } catch {}
+  try {
+    fs.unlinkSync(SIGNAL_FILE);
+  } catch {}
 });
 afterAll(() => {
   process.env.HOME = ORIG_HOME;
-  try { fs.rmSync(HOME_DIR, { recursive: true, force: true }); } catch {}
+  try {
+    fs.rmSync(HOME_DIR, { recursive: true, force: true });
+  } catch {}
 });
 
 describe("hook/_lib/signal — writeSignal", () => {
   it("v2 format with session id and cwd", () => {
     signal.writeSignal("done", "abc-123", "/Users/foo/proj");
-    expect(fs.readFileSync(SIGNAL_FILE, "utf-8")).toMatch(
-      /^done \d+ abc-123 \/Users\/foo\/proj$/
-    );
+    expect(fs.readFileSync(SIGNAL_FILE, "utf-8")).toMatch(/^done \d+ abc-123 \/Users\/foo\/proj$/);
   });
 
   it("v2 format without cwd", () => {

--- a/test/hook/lib.sounds.test.ts
+++ b/test/hook/lib.sounds.test.ts
@@ -28,19 +28,27 @@ describe("hook/_lib/sounds — resolveSound (active platform)", () => {
   it("unknown preset falls back to the platform-appropriate default", () => {
     const r = resolveSound("Nonexistent_Preset", "/mac-default", "C:\\win-default");
     // macOS → defaultMac; Linux → complete.oga; Windows → defaultWin.
-    expect([
-      "/mac-default",
-      "C:\\win-default",
-      `${LINUX_SOUNDS_DIR}/complete.oga`,
-    ]).toContain(r);
+    expect(["/mac-default", "C:\\win-default", `${LINUX_SOUNDS_DIR}/complete.oga`]).toContain(r);
   });
 });
 
 describe("hook/_lib/sounds — cross-platform tables", () => {
   it("MACOS_SOUNDS covers the 14-preset enum", () => {
     expect(Object.keys(MACOS_SOUNDS).sort()).toEqual([
-      "Basso", "Blow", "Bottle", "Frog", "Funk", "Glass", "Hero",
-      "Morse", "Ping", "Pop", "Purr", "Sosumi", "Submarine", "Tink",
+      "Basso",
+      "Blow",
+      "Bottle",
+      "Frog",
+      "Funk",
+      "Glass",
+      "Hero",
+      "Morse",
+      "Ping",
+      "Pop",
+      "Purr",
+      "Sosumi",
+      "Submarine",
+      "Tink",
     ]);
     for (const v of Object.values(MACOS_SOUNDS)) {
       expect(v).toMatch(/^\/System\/Library\/Sounds\/.+\.aiff$/);
@@ -49,8 +57,14 @@ describe("hook/_lib/sounds — cross-platform tables", () => {
 
   it("WIN_SOUNDS covers the 8 Windows presets", () => {
     expect(Object.keys(WIN_SOUNDS).sort()).toEqual([
-      "Windows Background", "Windows Notify", "chimes", "chord", "ding",
-      "notify", "ringin", "tada",
+      "Windows Background",
+      "Windows Notify",
+      "chimes",
+      "chord",
+      "ding",
+      "notify",
+      "ringin",
+      "tada",
     ]);
     for (const v of Object.values(WIN_SOUNDS)) {
       expect(v).toMatch(/^C:\\Windows\\Media\\.+\.wav$/);

--- a/test/hook/on-notification.test.ts
+++ b/test/hook/on-notification.test.ts
@@ -20,11 +20,7 @@ describe("hook: claude-notifier-on-notification", () => {
   });
 
   it("non-permission_prompt notification_type is ignored", () => {
-    const res = runHook(
-      SCRIPT,
-      { notification_type: "idle", session_id: "s-1" },
-      home.root
-    );
+    const res = runHook(SCRIPT, { notification_type: "idle", session_id: "s-1" }, home.root);
     expect(res.status).toBe(0);
     expect(readSignal(home.signalFile)).toBe("");
   });

--- a/test/hook/on-permission.test.ts
+++ b/test/hook/on-permission.test.ts
@@ -21,11 +21,7 @@ describe("hook: claude-notifier-on-permission", () => {
   });
 
   it("AskUserQuestion is skipped (handled by the question hook)", () => {
-    const res = runHook(
-      SCRIPT,
-      { tool_name: "AskUserQuestion", session_id: "s-1" },
-      home.root
-    );
+    const res = runHook(SCRIPT, { tool_name: "AskUserQuestion", session_id: "s-1" }, home.root);
     expect(res.status).toBe(0);
     expect(readSignal(home.signalFile)).toBe("");
   });
@@ -39,10 +35,7 @@ describe("hook: claude-notifier-on-permission", () => {
   });
 
   it("level=off: exits before signal write", () => {
-    fs.writeFileSync(
-      home.configFile,
-      JSON.stringify({ needsPermission: { level: "off" } })
-    );
+    fs.writeFileSync(home.configFile, JSON.stringify({ needsPermission: { level: "off" } }));
     const res = runHook(SCRIPT, { tool_name: "Bash", session_id: "s-1" }, home.root);
     expect(res.status).toBe(0);
     expect(readSignal(home.signalFile)).toBe("");

--- a/test/hook/on-question.test.ts
+++ b/test/hook/on-question.test.ts
@@ -31,11 +31,7 @@ describe("hook: claude-notifier-on-question", () => {
 
   it("muted: exits before signal write", () => {
     fs.writeFileSync(home.muteFlag, "");
-    const res = runHook(
-      SCRIPT,
-      { tool_name: "AskUserQuestion", session_id: "s-1" },
-      home.root
-    );
+    const res = runHook(SCRIPT, { tool_name: "AskUserQuestion", session_id: "s-1" }, home.root);
     expect(res.status).toBe(0);
     expect(readSignal(home.signalFile)).toBe("");
     expect(res.durationMs).toBeLessThan(500);
@@ -43,11 +39,7 @@ describe("hook: claude-notifier-on-question", () => {
 
   it("level=off: exits before signal write", () => {
     fs.writeFileSync(home.configFile, JSON.stringify({ asksQuestion: { level: "off" } }));
-    const res = runHook(
-      SCRIPT,
-      { tool_name: "AskUserQuestion", session_id: "s-1" },
-      home.root
-    );
+    const res = runHook(SCRIPT, { tool_name: "AskUserQuestion", session_id: "s-1" }, home.root);
     expect(res.status).toBe(0);
     expect(readSignal(home.signalFile)).toBe("");
   });

--- a/test/unit/hooks.cmd.test.ts
+++ b/test/unit/hooks.cmd.test.ts
@@ -8,9 +8,7 @@ describe("hookCmd", () => {
       return { ...actual, IS_WIN: false };
     });
     const { hookCmd } = await import("../../src/hooks/cmd");
-    expect(hookCmd("/Users/foo/.claude/hooks/x.js")).toBe(
-      'node "/Users/foo/.claude/hooks/x.js"'
-    );
+    expect(hookCmd("/Users/foo/.claude/hooks/x.js")).toBe('node "/Users/foo/.claude/hooks/x.js"');
     vi.doUnmock("../../src/paths");
   });
 
@@ -34,9 +32,7 @@ describe("hookCmd", () => {
       return { ...actual, IS_WIN: false };
     });
     const { hookCmd } = await import("../../src/hooks/cmd");
-    expect(hookCmd("/Users/foo/My Folder/hook.js")).toBe(
-      'node "/Users/foo/My Folder/hook.js"'
-    );
+    expect(hookCmd("/Users/foo/My Folder/hook.js")).toBe('node "/Users/foo/My Folder/hook.js"');
     vi.doUnmock("../../src/paths");
   });
 });

--- a/test/unit/hooks.registry.test.ts
+++ b/test/unit/hooks.registry.test.ts
@@ -1,10 +1,5 @@
 import { describe, it, expect } from "vitest";
-import {
-  HOOKS,
-  hookFileName,
-  hookDestPath,
-  ALL_HOOK_TYPES,
-} from "../../src/hooks/registry";
+import { HOOKS, hookFileName, hookDestPath, ALL_HOOK_TYPES } from "../../src/hooks/registry";
 import { HOOK_EXT, HOOKS_DIR } from "../../src/paths";
 
 describe("HOOKS registry", () => {

--- a/test/unit/settings.claude.test.ts
+++ b/test/unit/settings.claude.test.ts
@@ -17,7 +17,9 @@ describe("stripClaudeNotifierHooks", () => {
       hooks: {
         Stop: [notifierEntry("node ~/.claude/hooks/claude-notifier-on-stop.js")],
         PermissionRequest: [notifierEntry("node ~/.claude/hooks/claude-notifier-on-permission.js")],
-        PreToolUse: [notifierEntry("node ~/.claude/hooks/claude-notifier-on-question.js", "AskUserQuestion")],
+        PreToolUse: [
+          notifierEntry("node ~/.claude/hooks/claude-notifier-on-question.js", "AskUserQuestion"),
+        ],
         Notification: [notifierEntry("node ~/.claude/hooks/claude-notifier-on-notification.js")],
         UserPromptSubmit: [notifierEntry("node ~/.claude/hooks/claude-notifier-on-prompt.js")],
       },
@@ -31,10 +33,7 @@ describe("stripClaudeNotifierHooks", () => {
   it("preserves third-party entries on the same hook type", () => {
     const settings = {
       hooks: {
-        Stop: [
-          notifierEntry("node ~/.claude/hooks/claude-notifier-on-stop.js"),
-          thirdPartyEntry(),
-        ],
+        Stop: [notifierEntry("node ~/.claude/hooks/claude-notifier-on-stop.js"), thirdPartyEntry()],
       },
     };
 
@@ -86,9 +85,7 @@ describe("stripClaudeNotifierHooks", () => {
   it("matches by command substring — any 'claude-notifier' in command is filtered", () => {
     const settings = {
       hooks: {
-        Stop: [
-          { hooks: [{ type: "command", command: "/odd/path/claude-notifier-wrapper.sh" }] },
-        ],
+        Stop: [{ hooks: [{ type: "command", command: "/odd/path/claude-notifier-wrapper.sh" }] }],
       },
     };
     stripClaudeNotifierHooks(settings);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "lib": ["ES2020"],
     "sourceMap": true,
     "strict": true,
+    "noUncheckedIndexedAccess": true,
     "esModuleInterop": true,
     "skipLibCheck": true
   },

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -4,5 +4,5 @@
     "noEmit": true,
     "types": ["node", "vscode"]
   },
-  "include": ["src", "test"]
+  "include": ["src", "test", "vitest.config.ts", "eslint.config.mjs"]
 }


### PR DESCRIPTION
## Summary

Adds the quality gates Phase 7 (CI) will call. Scoped tight to **catches strict TypeScript doesn't already cover** — kitchen-sink configs intentionally skipped.

## What's added

| | What | Solves |
|---|---|---|
| \`tsconfig.json\` | \`noUncheckedIndexedAccess: true\` | Array/object index access now types as \`T \| undefined\`. Real bug class; existing code already defended (no fallout) |
| \`eslint.config.mjs\` (flat) | typescript-eslint recommended + \`no-floating-promises\` + \`no-misused-promises\` | Forgotten awaits and async-callback-where-sync-expected — the bug classes strict TS misses |
| \`.prettierrc\` + \`.prettierignore\` | Default formatting, \`*.md\` + \`LICENSE*\` excluded | Ends bikeshedding on PRs; lets prose owners keep their wrap |
| \`scripts/smoke.sh\` | Builds .vsix, asserts required files present, drives 4 hook scripts via stdin, verifies signal payloads + mute short-circuit | Agent-less pre-release sanity |
| \`package.json\` scripts | \`typecheck\`, \`lint\`, \`lint:fix\`, \`format\`, \`format:check\`, \`smoke\` | Phase 7 CI calls these |

## What's deliberately NOT added

- \`no-explicit-any\` / \`no-unsafe-*\` — \`~/.claude/settings.json\` is user-owned freeform JSON typed \`any\` on purpose. The cascade of unsafe warnings on every settings access is noise.
- \`noImplicitOverride\`, \`exactOptionalPropertyTypes\` — no classes / no optional-prop gotchas in this code.
- Husky / lint-staged — CI catches the same regressions; pre-commit adds friction for first-time contributors.

## Notes

- 35 source files auto-formatted by Prettier on first run. Diff is mostly whitespace + line wrap.
- Hook \`.js\` files get a non-type-checked ESLint block (they're plain Node, not in any tsconfig).
- The smoke script uses \`command -v node\` for an absolute node path so the \`PATH=/\` scrub (which suppresses afplay/notify-send for quiet runs) doesn't strand the node lookup itself.

## Verification

- [x] \`npm run typecheck\` — clean
- [x] \`npm run lint\` — clean
- [x] \`npm run format:check\` — clean (post-format)
- [x] \`npm test\` — 51/51 pass
- [x] \`npm run smoke\` — builds .vsix + asserts all hook flows
- [ ] CI workflow (next PR) wires all six scripts into a matrix

## Test plan after merge

The gates start enforcing on the next PR to staging — Phase 7 (CI) adds the workflow that runs them. Until then, contributors can run \`npm test && npm run typecheck && npm run lint && npm run format:check && npm run smoke\` locally.