### PR TITLE
ci: github-actions workflow + dependabot

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+# Enforce LF line endings on all text files, regardless of host OS. Prevents
+# CRLF from sneaking in via Windows checkouts and breaking Prettier/format
+# checks on CI.
+* text=auto eol=lf
+
+# Binary files: keep as-is.
+*.png binary
+*.wav binary
+*.aiff binary
+*.vsix binary

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      eslint:
+        patterns: ["eslint*", "typescript-eslint", "@typescript-eslint/*"]
+      vitest:
+        patterns: ["vitest", "@vitest/*"]
+      types:
+        patterns: ["@types/*"]
+      vscode:
+        patterns: ["@vscode/*"]
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,73 @@
+name: ci
+
+on:
+  push:
+    branches: [main, staging]
+  pull_request:
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  ci:
+    name: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Format check
+        run: npm run format:check
+
+      - name: Unit tests
+        run: npm run test:unit
+
+      - name: Hook tests
+        run: npm run test:hook
+
+      - name: Package .vsix
+        # vsce package is the same on every OS; running it on all three
+        # confirms the build is reproducible everywhere we ship to.
+        run: npm run package
+
+      - name: Upload .vsix artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: claude-notifier-${{ matrix.os }}
+          path: "*.vsix"
+          retention-days: 14
+
+  smoke:
+    # Runs only after CI passes on every matrix arm. macOS-only because
+    # scripts/smoke.sh exercises the .js hooks (afplay path is mac-specific,
+    # and the rest of the script is bash). PowerShell hook smoke can be
+    # added later when we wire pwsh-based smoke for Windows.
+    name: smoke (macos)
+    needs: ci
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run smoke

--- a/.prettierrc
+++ b/.prettierrc
@@ -4,5 +4,6 @@
   "semi": true,
   "singleQuote": false,
   "trailingComma": "es5",
-  "arrowParens": "always"
+  "arrowParens": "always",
+  "endOfLine": "lf"
 }

--- a/test/hook/lib.sounds.test.ts
+++ b/test/hook/lib.sounds.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import * as path from "path";
 import {
   resolveSound,
   MACOS_SOUNDS,
@@ -85,13 +86,19 @@ describe("hook/_lib/sounds — cross-platform tables", () => {
 });
 
 describe("hook/_lib/sounds — BUNDLED_FALLBACK", () => {
+  // path.join uses the platform separator, so endsWith assertions adapt
+  // automatically (forward slash on Unix, backslash on Windows).
   it("exposes a bundled fallback for each event kind", () => {
-    expect(BUNDLED_FALLBACK.taskCompleted).toMatch(/sounds\/task-complete\.wav$/);
-    expect(BUNDLED_FALLBACK.needsPermission).toMatch(/sounds\/needs-input\.wav$/);
-    expect(BUNDLED_FALLBACK.asksQuestion).toMatch(/sounds\/question\.wav$/);
+    expect(BUNDLED_FALLBACK.taskCompleted.endsWith(path.join("sounds", "task-complete.wav"))).toBe(
+      true
+    );
+    expect(BUNDLED_FALLBACK.needsPermission.endsWith(path.join("sounds", "needs-input.wav"))).toBe(
+      true
+    );
+    expect(BUNDLED_FALLBACK.asksQuestion.endsWith(path.join("sounds", "question.wav"))).toBe(true);
   });
 
   it("BUNDLED_SOUNDS_DIR resolves under hook/_lib/sounds/ (deploy target)", () => {
-    expect(BUNDLED_SOUNDS_DIR.endsWith("/hook/_lib/sounds")).toBe(true);
+    expect(BUNDLED_SOUNDS_DIR.endsWith(path.join("hook", "_lib", "sounds"))).toBe(true);
   });
 });

--- a/test/unit/hooks.registry.test.ts
+++ b/test/unit/hooks.registry.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import * as path from "path";
 import { HOOKS, hookFileName, hookDestPath, ALL_HOOK_TYPES } from "../../src/hooks/registry";
 import { HOOK_EXT, HOOKS_DIR } from "../../src/paths";
 
@@ -50,7 +51,7 @@ describe("HOOKS registry", () => {
 
   it("hookDestPath is HOOKS_DIR + filename", () => {
     for (const hook of HOOKS) {
-      expect(hookDestPath(hook)).toBe(`${HOOKS_DIR}/${hookFileName(hook)}`);
+      expect(hookDestPath(hook)).toBe(path.join(HOOKS_DIR, hookFileName(hook)));
     }
   });
 });

--- a/test/unit/routing.cwd.test.ts
+++ b/test/unit/routing.cwd.test.ts
@@ -1,39 +1,48 @@
 import { describe, it, expect } from "vitest";
+import * as path from "path";
 import { cwdMatchesFolder } from "../../src/routing/cwd";
+
+// cwdMatchesFolder uses path.sep at runtime, so test paths use path.join
+// to stay platform-correct (\\ on Windows, / elsewhere).
+const ROOT = path.join(path.sep, "Users", "foo", "proj");
+const SRC = path.join(ROOT, "src");
+const NESTED = path.join(ROOT, "src", "a", "b", "c");
 
 describe("cwdMatchesFolder", () => {
   it("exact match", () => {
-    expect(cwdMatchesFolder("/Users/foo/proj", "/Users/foo/proj")).toBe(true);
+    expect(cwdMatchesFolder(ROOT, ROOT)).toBe(true);
   });
 
   it("cwd inside folder", () => {
-    expect(cwdMatchesFolder("/Users/foo/proj/src", "/Users/foo/proj")).toBe(true);
+    expect(cwdMatchesFolder(SRC, ROOT)).toBe(true);
   });
 
   it("cwd deeply nested in folder", () => {
-    expect(cwdMatchesFolder("/Users/foo/proj/src/a/b/c", "/Users/foo/proj")).toBe(true);
+    expect(cwdMatchesFolder(NESTED, ROOT)).toBe(true);
   });
 
   it("trailing separator on folder doesn't break match", () => {
-    expect(cwdMatchesFolder("/Users/foo/proj/src", "/Users/foo/proj/")).toBe(true);
+    expect(cwdMatchesFolder(SRC, ROOT + path.sep)).toBe(true);
   });
 
   it("sibling folder is NOT a match (prefix collision avoided)", () => {
-    // "/Users/foo/proj-other" starts with "/Users/foo/proj" textually but is
-    // a different directory. The trailing-separator check guards this.
-    expect(cwdMatchesFolder("/Users/foo/proj-other", "/Users/foo/proj")).toBe(false);
+    // "<root>-other" starts with "<root>" textually but is a different dir.
+    // The trailing-separator check guards this.
+    expect(cwdMatchesFolder(ROOT + "-other", ROOT)).toBe(false);
   });
 
-  it("sibling at root is NOT a match", () => {
-    expect(cwdMatchesFolder("/Users/foo/projects-other", "/Users/foo/projects")).toBe(false);
+  it("sibling at projects level is NOT a match", () => {
+    const projects = path.join(path.sep, "Users", "foo", "projects");
+    const projectsOther = path.join(path.sep, "Users", "foo", "projects-other");
+    expect(cwdMatchesFolder(projectsOther, projects)).toBe(false);
   });
 
   it("empty cwd does not match anything", () => {
-    expect(cwdMatchesFolder("", "/Users/foo/proj")).toBe(false);
+    expect(cwdMatchesFolder("", ROOT)).toBe(false);
   });
 
   it("empty folder does not match anything", () => {
-    expect(cwdMatchesFolder("/Users/foo/proj", "")).toBe(false);
+    expect(cwdMatchesFolder(ROOT, "")).toBe(false);
   });
 
   it("both empty is not a match", () => {
@@ -41,6 +50,7 @@ describe("cwdMatchesFolder", () => {
   });
 
   it("cwd is parent of folder is NOT a match", () => {
-    expect(cwdMatchesFolder("/Users/foo", "/Users/foo/proj")).toBe(false);
+    const parent = path.join(path.sep, "Users", "foo");
+    expect(cwdMatchesFolder(parent, ROOT)).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Three-OS matrix (ubuntu / macos / windows) that runs the gate scripts wired in #25 on every push to \`main\`/\`staging\` and every PR. Plus a Dependabot config.

## What's gated

\`\`\`
npm ci
npm run typecheck     (tsc --noEmit)
npm run lint          (eslint flat config)
npm run format:check  (prettier --check)
npm run test:unit     (vitest, 57 tests)
npm run test:hook     (vitest subprocess + lib, 51 tests)
npm run package       (vsce package → upload as artifact, 14-day retention)
\`\`\`

A separate \`smoke\` job runs **only after** all three OS arms pass, macOS-only because [scripts/smoke.sh](scripts/smoke.sh) exercises the \`.js\` hooks (afplay-specific) and is bash. PowerShell-side smoke for Windows is deferred.

## Concurrency

\`concurrency.cancel-in-progress: true\` per branch — pushing again to a PR cancels the prior run instead of queueing.

## Dependabot

Weekly npm + github-actions updates. PRs grouped by maintainer to keep the queue manageable:

| Group | Patterns |
|---|---|
| eslint | \`eslint*\`, \`typescript-eslint\`, \`@typescript-eslint/*\` |
| vitest | \`vitest\`, \`@vitest/*\` |
| types | \`@types/*\` |
| vscode | \`@vscode/*\` |

Limit: 5 npm + 3 actions PRs open at once.

## Out of scope

- Integration tests via \`@vscode/test-electron\` — Phase 8.
- CodeQL — can add if there's a concrete reason; default JS/TS scan adds minor noise without much catch for this codebase.
- Release workflow (\`vsce publish\` on workflow_dispatch) — Phase 9.

## Test plan

The CI workflow self-validates: this PR triggers it. If the matrix is green on all three OSes for the gate scripts we wired in #25, ship it. If something fails, the failure points to the actual gate that needs fixing — that's the value of having CI exist.