### PR TITLE
ci: dedupe workflow triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,11 +2,14 @@ name: ci
 
 on:
   push:
-    branches: [main, staging]
+    branches: [main]
   pull_request:
 
 concurrency:
-  group: ci-${{ github.workflow }}-${{ github.ref }}
+  # PRs group by PR number (so a force-push cancels the prior run for the
+  # same PR). Pushes to main group by ref. This separation prevents the
+  # push and pull_request events from racing on the same commit.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Change

\`.github/workflows/ci.yml\`:

| Field | Before | After |
|---|---|---|
| \`on.push.branches\` | \`[main, staging]\` | \`[main]\` |
| \`on.pull_request\` | unchanged | unchanged |
| \`concurrency.group\` | \`ci-\${{ github.workflow }}-\${{ github.ref }}\` | \`\${{ github.workflow }}-\${{ github.event.pull_request.number \|\| github.ref }}\` |

## Result

| Scenario | Before | After |
|---|---|---|
| PR opened/sync, target=staging | 2 runs per matrix arm (push + pull_request) | 1 run per matrix arm (pull_request) |
| Squash-merge PR to staging | 1 push run | none — already validated by the PR's pull_request run |
| Squash-merge PR to main | 1 push run | 1 push run (validates the release commit) |
| Force-push to open PR | both prior runs continue | prior run cancelled, new one starts |

## Test plan

- [x] Workflow YAML lints (run locally via `actionlint` not required for trivial trigger changes)
- [ ] After merge: open a noop PR and confirm only 4 check entries appear instead of 8