### PR TITLE
feat: clickable Claude Notifier macOS notifications + focus the originating tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- Click-to-focus the originating Claude session. When a Stop notification is clicked (via `terminal-notifier` on macOS) or the **Reveal** action button on the VS Code toast, the extension now reveals the specific integrated terminal or editor panel where Claude was running — not just the workspace window. Implementation: Stop hooks capture the ancestor PID chain on macOS/Linux and send it in the v2 signal; the extension matches a terminal's `processId` against the chain and falls back to `claude-vscode.editor.open <session_id>` for editor panels. Original feature idea by [@marco-lavagnino](https://github.com/marco-lavagnino) in [#15](https://github.com/ashmitb95/claude-notifier/pull/15).
+
 ## [3.0.0] - 2026-05-16
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Click-to-focus the originating Claude session. When a Stop notification is clicked (via `terminal-notifier` on macOS) or the **Reveal** action button on the VS Code toast, the extension now reveals the specific integrated terminal or editor panel where Claude was running — not just the workspace window. Implementation: Stop hooks capture the ancestor PID chain on macOS/Linux and send it in the v2 signal; the extension matches a terminal's `processId` against the chain and falls back to `claude-vscode.editor.open <session_id>` for editor panels. Original feature idea by [@marco-lavagnino](https://github.com/marco-lavagnino) in [#15](https://github.com/ashmitb95/claude-notifier/pull/15).
+- Permission and question macOS notifications are now clickable. Previously, clicking either notification opened Script Editor (they were emitted through `osascript`). They now go through `terminal-notifier` like the Stop notification: clicks run `code <cwd>` to focus the matching VS Code window — falling back to `osascript activate` when the `code` CLI isn't on `PATH` — and write the firing cwd to `~/.claude/hooks/claude-notifier-focus` so the focus watcher reveals the originating Claude tab when one was previously recorded.
 
 ## [3.0.0] - 2026-05-16
 

--- a/hook/_lib/click.js
+++ b/hook/_lib/click.js
@@ -1,0 +1,31 @@
+const { FOCUS_SIGNAL_FILE } = require("./paths");
+
+// POSIX single-quote escape: anything inside '...' is literal except ', which
+// closes the quoted run, then we insert '\\'' (escaped quote), then reopen.
+function shQuote(s) {
+  return `'${String(s).replace(/'/g, `'\\''`)}'`;
+}
+
+/**
+ * Build the shell snippet passed as terminal-notifier's -execute. On click:
+ *   1. Write the firing cwd to FOCUS_SIGNAL_FILE so the extension's focus
+ *      watcher reveals the matching Claude tab (when an extension is active
+ *      in that window — graceful no-op otherwise).
+ *   2. Bring the matching VS Code window forward via `code <cwd>`, falling
+ *      back to a generic AppleScript activate when `code` isn't on PATH.
+ *
+ * Returns null when cwd is empty — callers fall back to a generic activate.
+ */
+function buildClickAction(cwd) {
+  if (!cwd) return null;
+  const cwdQ = shQuote(cwd);
+  const focusQ = shQuote(FOCUS_SIGNAL_FILE);
+  const focusWrite = `printf '%s' ${cwdQ} > ${focusQ}`;
+  const bringForward = `{ code ${cwdQ} 2>/dev/null || osascript -e 'tell application "Visual Studio Code" to activate'; }`;
+  return `${focusWrite}; ${bringForward}`;
+}
+
+/** Generic VS Code activate — no per-window precision. Used when cwd unknown. */
+const GENERIC_ACTIVATE = `osascript -e 'tell application "Visual Studio Code" to activate'`;
+
+module.exports = { buildClickAction, GENERIC_ACTIVATE };

--- a/hook/_lib/notify.js
+++ b/hook/_lib/notify.js
@@ -34,11 +34,17 @@ function findTerminalNotifier() {
  *
  * On macOS: when opts.preferTerminalNotifier is true and terminal-notifier is
  * installed, use it (gives clickable notifications that focus VS Code). Else
- * falls back to osascript. Non-stop hooks set this to false because the
- * popup is short-lived and clickability matters less when the user is active.
+ * falls back to osascript.
+ *
+ * opts.executeCmd (macOS, terminal-notifier path only): shell snippet run when
+ * the user clicks the notification — typically brings VS Code forward and
+ * writes the focus-signal file so the extension reveals the matching tab.
+ * Ignored when terminal-notifier isn't installed (osascript notifications
+ * can't carry a click action; their click defaults to Script Editor).
  */
 function showNotification(message, opts = {}) {
   const preferTn = !!opts.preferTerminalNotifier;
+  const executeCmd = opts.executeCmd;
   try {
     if (USE_WIN) {
       const safeMsg = psSingleQuoteEscape(message);
@@ -58,7 +64,9 @@ function showNotification(message, opts = {}) {
       if (preferTn) {
         const tn = findTerminalNotifier();
         if (tn) {
-          execFileSync(tn, ["-title", TITLE, "-message", String(message)], { stdio: "ignore" });
+          const args = ["-title", TITLE, "-message", String(message)];
+          if (executeCmd) args.push("-execute", executeCmd);
+          execFileSync(tn, args, { stdio: "ignore" });
           return;
         }
       }

--- a/hook/_lib/paths.js
+++ b/hook/_lib/paths.js
@@ -3,7 +3,8 @@ const path = require("path");
 const HOOKS_DIR = path.join(process.env.HOME || process.env.USERPROFILE || "~", ".claude", "hooks");
 const MUTE_FLAG = path.join(HOOKS_DIR, "claude-notifier-muted");
 const SIGNAL_FILE = path.join(HOOKS_DIR, "claude-signal");
+const FOCUS_SIGNAL_FILE = path.join(HOOKS_DIR, "claude-notifier-focus");
 const CONFIG_FILE = path.join(HOOKS_DIR, "claude-notifier-config.json");
 const ACTIVE_DIR = path.join(HOOKS_DIR, "claude-notifier-active.d");
 
-module.exports = { HOOKS_DIR, MUTE_FLAG, SIGNAL_FILE, CONFIG_FILE, ACTIVE_DIR };
+module.exports = { HOOKS_DIR, MUTE_FLAG, SIGNAL_FILE, FOCUS_SIGNAL_FILE, CONFIG_FILE, ACTIVE_DIR };

--- a/hook/_lib/pid.js
+++ b/hook/_lib/pid.js
@@ -1,0 +1,38 @@
+const { execFileSync } = require("child_process");
+const { IS_WIN } = require("./platform");
+
+function readParentPid(pid) {
+  try {
+    const out = execFileSync("/bin/ps", ["-o", "ppid=", "-p", String(pid)], {
+      encoding: "utf-8",
+      timeout: 500,
+    }).trim();
+    const parsed = parseInt(out, 10);
+    return Number.isFinite(parsed) && parsed > 1 ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Walk the ancestor chain starting from the hook's parent process.
+ * Returns ordered PIDs from immediate parent upward, stopping at init,
+ * loops, or the depth cap. Empty array on Windows.
+ */
+function getAncestorPids(maxDepth = 10) {
+  if (IS_WIN) return [];
+  const chain = [];
+  const seen = new Set();
+  let cur = process.ppid;
+  while (cur && cur > 1 && chain.length < maxDepth) {
+    if (seen.has(cur)) break;
+    seen.add(cur);
+    chain.push(cur);
+    const next = readParentPid(cur);
+    if (!next) break;
+    cur = next;
+  }
+  return chain;
+}
+
+module.exports = { getAncestorPids };

--- a/hook/_lib/signal.js
+++ b/hook/_lib/signal.js
@@ -4,23 +4,28 @@ const { SIGNAL_FILE } = require("./paths");
 /**
  * Write a signal for the extension to consume.
  *
- * Format v2 (current): "<reason> <ts> <session_id|-> <cwd?>"
+ * Format v2 (current): "<reason> <ts> <session_id|-> [<pid_chain_csv>] <cwd?>"
  *   session_id is a single token (no whitespace); "-" when absent.
- *   cwd is optional — Stop includes it for per-window routing; others omit it.
+ *   pid_chain_csv is comma-separated ancestor PIDs; omitted when absent.
+ *   The parser distinguishes pid_chain from cwd by shape: digits+commas vs
+ *   the path separator in cwd. Stop hooks emit pid_chain on macOS/Linux to
+ *   support click-to-focus the originating terminal or editor tab.
  *
  * Format v1 (legacy): "<reason> <ts> <cwd?>"
  *   Still accepted by the parser for back-compat with older deployed hooks.
  *   New writes always use v2.
  */
-function writeSignal(reason, sessionId, cwd) {
+function writeSignal(reason, sessionId, cwd, pidChain) {
   try {
     const ts = Date.now();
-    // Session id may contain anything Claude Code chooses to send. Strip
-    // whitespace defensively so the space-delimited signal format stays
-    // parseable. Empty/missing → "-".
     const sid = sessionId ? String(sessionId).replace(/\s+/g, "") : "-";
     const safeSid = sid || "-";
-    const payload = cwd ? `${reason} ${ts} ${safeSid} ${cwd}` : `${reason} ${ts} ${safeSid}`;
+    const hasChain = Array.isArray(pidChain) && pidChain.length > 0;
+    const chainCsv = hasChain ? pidChain.filter((n) => Number.isInteger(n) && n > 0).join(",") : "";
+    const middle = chainCsv ? ` ${chainCsv}` : "";
+    const payload = cwd
+      ? `${reason} ${ts} ${safeSid}${middle} ${cwd}`
+      : `${reason} ${ts} ${safeSid}${middle}`;
     fs.writeFileSync(SIGNAL_FILE, payload);
   } catch {}
 }

--- a/hook/claude-notifier-on-permission.js
+++ b/hook/claude-notifier-on-permission.js
@@ -6,6 +6,7 @@ const { resolveSound, BUNDLED_FALLBACK } = require("./_lib/sounds");
 const { playSound } = require("./_lib/play");
 const { showNotification } = require("./_lib/notify");
 const { writeSignal } = require("./_lib/signal");
+const { buildClickAction, GENERIC_ACTIVATE } = require("./_lib/click");
 
 let raw = "";
 process.stdin.setEncoding("utf-8");
@@ -39,7 +40,11 @@ process.stdin.on("end", () => {
 
   if (level === "sound+popup" || level === "popup") {
     const tool = input.tool_name || "a tool";
-    showNotification(`Claude needs permission to use ${tool}.`);
+    const cwd = (input && input.cwd) || process.cwd() || "";
+    showNotification(`Claude needs permission to use ${tool}.`, {
+      preferTerminalNotifier: true,
+      executeCmd: buildClickAction(cwd) || GENERIC_ACTIVATE,
+    });
   }
 
   writeSignal("input", input.session_id);

--- a/hook/claude-notifier-on-question.js
+++ b/hook/claude-notifier-on-question.js
@@ -6,6 +6,7 @@ const { resolveSound, BUNDLED_FALLBACK } = require("./_lib/sounds");
 const { playSound } = require("./_lib/play");
 const { showNotification } = require("./_lib/notify");
 const { writeSignal } = require("./_lib/signal");
+const { buildClickAction, GENERIC_ACTIVATE } = require("./_lib/click");
 
 let raw = "";
 process.stdin.setEncoding("utf-8");
@@ -38,7 +39,11 @@ process.stdin.on("end", () => {
   }
 
   if (level === "sound+popup" || level === "popup") {
-    showNotification("Claude is asking you a question.");
+    const cwd = (input && input.cwd) || process.cwd() || "";
+    showNotification("Claude is asking you a question.", {
+      preferTerminalNotifier: true,
+      executeCmd: buildClickAction(cwd) || GENERIC_ACTIVATE,
+    });
   }
 
   writeSignal("question", input.session_id);

--- a/hook/claude-notifier-on-stop.js
+++ b/hook/claude-notifier-on-stop.js
@@ -9,6 +9,7 @@ const { playSound } = require("./_lib/play");
 const { showNotification } = require("./_lib/notify");
 const { extensionOwnsCwd } = require("./_lib/active");
 const { writeSignal } = require("./_lib/signal");
+const { getAncestorPids } = require("./_lib/pid");
 
 let raw = "";
 process.stdin.setEncoding("utf-8");
@@ -25,8 +26,9 @@ process.stdin.on("end", () => {
   if (isMuted()) process.exit(0);
 
   const cwd = (input && input.cwd) || process.cwd() || "";
+  const pidChain = getAncestorPids();
 
-  writeSignal("done", input.session_id, cwd);
+  writeSignal("done", input.session_id, cwd, pidChain);
 
   // If a VSCode window owns this cwd, the extension handles sound/notification
   // with debounce. Otherwise fall through to direct playback.

--- a/hook/claude-notifier-on-stop.js
+++ b/hook/claude-notifier-on-stop.js
@@ -10,6 +10,7 @@ const { showNotification } = require("./_lib/notify");
 const { extensionOwnsCwd } = require("./_lib/active");
 const { writeSignal } = require("./_lib/signal");
 const { getAncestorPids } = require("./_lib/pid");
+const { buildClickAction, GENERIC_ACTIVATE } = require("./_lib/click");
 
 let raw = "";
 process.stdin.setEncoding("utf-8");
@@ -51,7 +52,10 @@ process.stdin.on("end", () => {
   if (level === "sound+popup" || level === "popup") {
     // Stop notifications fire when the user is likely away — prefer
     // terminal-notifier so the click can focus VS Code.
-    showNotification("Claude has finished the task.", { preferTerminalNotifier: true });
+    showNotification("Claude has finished the task.", {
+      preferTerminalNotifier: true,
+      executeCmd: buildClickAction(cwd) || GENERIC_ACTIVATE,
+    });
   }
 
   process.exit(0);

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -60,11 +60,12 @@ run_hook() {
   echo "$stdin" | HOME="$TMPHOME" PATH=/ "$NODE_BIN" "$REPO/hook/$name.js"
 }
 
-# Stop: expect "done <ts> <sid> <cwd>"
+# Stop: expect "done <ts> <sid> [<pid_chain>] <cwd>" — pid_chain present on
+# macOS/Linux, absent on Windows. The bracketed alternation tolerates both.
 > "$TMPHOME/.claude/hooks/claude-signal"
 run_hook claude-notifier-on-stop '{"session_id":"smoke","cwd":"/tmp/x"}'
 sig="$(cat "$TMPHOME/.claude/hooks/claude-signal" 2>/dev/null || echo '')"
-[[ "$sig" =~ ^done\ [0-9]+\ smoke\ /tmp/x$ ]] || fail "stop signal wrong: $sig"
+[[ "$sig" =~ ^done\ [0-9]+\ smoke(\ [0-9,]+)?\ /tmp/x$ ]] || fail "stop signal wrong: $sig"
 pass "stop hook: $sig"
 
 # Permission: expect "input <ts> <sid>"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,6 +5,7 @@ import { syncConfig } from "./settings/sync";
 import { setupHooks } from "./hooks/lifecycle";
 import { initDiscovery, installTerminalNotifierFlow } from "./notifications/terminal-notifier";
 import { writeOwnPidFile, cleanStalePidFiles } from "./routing/cwd";
+import { startFocusSignalWatcher } from "./routing/focus";
 import { startSignalWatcher } from "./signals/dispatch";
 import { createStatusBar, toggleSound } from "./ui/status-bar";
 import { initLogger, log } from "./log";
@@ -43,7 +44,8 @@ export function activate(context: vscode.ExtensionContext) {
         syncConfig();
       }
     }),
-    startSignalWatcher()
+    startSignalWatcher(),
+    startFocusSignalWatcher()
   );
 }
 

--- a/src/notifications/local.ts
+++ b/src/notifications/local.ts
@@ -1,13 +1,13 @@
 import * as vscode from "vscode";
 import { exec } from "child_process";
-import { IS_WIN, IS_MAC } from "../paths";
+import { IS_WIN, IS_MAC, FOCUS_SIGNAL_FILE } from "../paths";
 import { getTerminalNotifierPath, getCodeCliPath } from "./terminal-notifier";
 
 function shellQuote(s: string): string {
   return `'${s.replace(/'/g, `'\\''`)}'`;
 }
 
-export function showLocalNotification(message: string): void {
+export function showLocalNotification(message: string, cwd?: string): void {
   if (IS_WIN) {
     const safeMsg = message.replace(/'/g, "''");
     const ps = `Add-Type -AssemblyName System.Windows.Forms; $n=New-Object System.Windows.Forms.NotifyIcon; $n.Icon=[System.Drawing.SystemIcons]::Information; $n.Visible=$true; $n.ShowBalloonTip(3000,'Claude Notifier','${safeMsg}',[System.Windows.Forms.ToolTipIcon]::None); Start-Sleep -m 500; $n.Dispose()`;
@@ -19,10 +19,18 @@ export function showLocalNotification(message: string): void {
     const tn = getTerminalNotifierPath()!;
     const folder = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath ?? "";
     const codeCli = getCodeCliPath();
-    const executeCmd =
+    // The click pipeline: terminal-notifier's -execute runs a shell snippet
+    // that (a) drops the originating cwd into FOCUS_SIGNAL_FILE so the
+    // extension watcher can reveal the matching Claude tab, and (b) brings
+    // the VS Code window forward via the code CLI (or osascript fallback).
+    const focusWrite = cwd
+      ? `printf '%s' ${shellQuote(cwd)} > ${shellQuote(FOCUS_SIGNAL_FILE)}`
+      : "";
+    const bringForward =
       codeCli && folder
         ? `${shellQuote(codeCli)} ${shellQuote(folder)}`
         : `osascript -e 'tell application "Visual Studio Code" to activate'`;
+    const executeCmd = focusWrite ? `${focusWrite}; ${bringForward}` : bringForward;
     const args = ["-title", "Claude Notifier", "-message", message, "-execute", executeCmd];
     exec(`${shellQuote(tn)} ${args.map(shellQuote).join(" ")}`);
   } else {

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -6,6 +6,7 @@ export const HOOKS_DIR = path.join(CLAUDE_DIR, "hooks");
 export const SETTINGS_FILE = path.join(CLAUDE_DIR, "settings.json");
 export const CONFIG_FILE = path.join(HOOKS_DIR, "claude-notifier-config.json");
 export const SIGNAL_FILE = path.join(HOOKS_DIR, "claude-signal");
+export const FOCUS_SIGNAL_FILE = path.join(HOOKS_DIR, "claude-notifier-focus");
 export const MUTE_FLAG = path.join(HOOKS_DIR, "claude-notifier-muted");
 
 // Directory of per-PID marker files. Hooks treat the extension as active if

--- a/src/routing/focus.ts
+++ b/src/routing/focus.ts
@@ -1,0 +1,105 @@
+import * as fs from "fs";
+import * as vscode from "vscode";
+import { FOCUS_SIGNAL_FILE } from "../paths";
+import { getOwnWorkspaceFolders, cwdMatchesFolder } from "./cwd";
+import { log } from "../log";
+
+export interface DoneContext {
+  sessionId: string | null;
+  pidChain: number[];
+  cwd: string;
+}
+
+const lastDoneByCwd = new Map<string, DoneContext>();
+
+export function rememberDone(ctx: DoneContext): void {
+  if (!ctx.cwd) return;
+  lastDoneByCwd.set(ctx.cwd, ctx);
+}
+
+export function getRememberedDone(cwd: string): DoneContext | null {
+  return lastDoneByCwd.get(cwd) ?? null;
+}
+
+export function resetDoneMemory(): void {
+  lastDoneByCwd.clear();
+}
+
+/**
+ * Reveal the originating Claude session: match the captured ancestor PIDs
+ * against integrated terminals first, then fall back to asking the Anthropic
+ * Claude Code extension to open the editor panel for the session id.
+ * Returns true when something was revealed.
+ */
+export async function revealClaudeTab(ctx: DoneContext | null): Promise<boolean> {
+  if (!ctx) return false;
+
+  if (ctx.pidChain.length > 0) {
+    for (const term of vscode.window.terminals) {
+      const pid = await term.processId;
+      if (pid && ctx.pidChain.includes(pid)) {
+        term.show();
+        return true;
+      }
+    }
+  }
+
+  if (ctx.sessionId) {
+    try {
+      await vscode.commands.executeCommand("claude-vscode.editor.open", ctx.sessionId);
+      return true;
+    } catch {
+      // Anthropic Claude Code extension not installed or command not registered.
+    }
+  }
+
+  return false;
+}
+
+let focusWatcher: fs.FSWatcher | null = null;
+
+/**
+ * Watch FOCUS_SIGNAL_FILE for terminal-notifier click signals. The file
+ * content is the cwd of the firing session. Only the window whose workspace
+ * contains that cwd acts.
+ */
+export function startFocusSignalWatcher(): vscode.Disposable {
+  if (!fs.existsSync(FOCUS_SIGNAL_FILE)) {
+    try {
+      fs.writeFileSync(FOCUS_SIGNAL_FILE, "");
+    } catch {}
+  }
+  try {
+    focusWatcher = fs.watch(FOCUS_SIGNAL_FILE, (eventType) => {
+      if (eventType === "change") {
+        handleFocusSignal();
+      }
+    });
+    log("focus-signal watcher started:", FOCUS_SIGNAL_FILE);
+  } catch (err) {
+    log("focus-signal watcher failed:", String(err));
+  }
+  return {
+    dispose: () => {
+      focusWatcher?.close();
+      focusWatcher = null;
+    },
+  };
+}
+
+function handleFocusSignal(): void {
+  let cwd = "";
+  try {
+    cwd = fs.readFileSync(FOCUS_SIGNAL_FILE, "utf-8").trim();
+  } catch {
+    return;
+  }
+  if (!cwd) return;
+
+  const folders = getOwnWorkspaceFolders();
+  if (folders.length > 0 && !folders.some((f) => cwdMatchesFolder(cwd, f))) {
+    return;
+  }
+
+  void revealClaudeTab(getRememberedDone(cwd));
+}

--- a/src/signals/dispatch.ts
+++ b/src/signals/dispatch.ts
@@ -6,6 +6,7 @@ import { parseSignal } from "./parser";
 import * as stage from "./stage";
 import { log } from "../log";
 import { getOwnWorkspaceFolders, cwdMatchesFolder } from "../routing/cwd";
+import { rememberDone, getRememberedDone, revealClaudeTab } from "../routing/focus";
 import { getEventLevel, getEventConfig } from "../settings/sync";
 import { playLocalSound } from "../notifications/sound";
 import { showLocalNotification } from "../notifications/local";
@@ -46,7 +47,7 @@ function handleSignal(): void {
   }
   if (!content) return;
 
-  const { reason, sessionId, cwd } = parseSignal(content);
+  const { reason, sessionId, cwd, pidChain } = parseSignal(content);
   log("signal:", reason, sessionId ?? "-", cwd || "(no cwd)");
 
   // UserPromptSubmit is coordination-only — advance the stage and exit.
@@ -66,13 +67,17 @@ function handleSignal(): void {
     }
   }
 
+  if (reason === "done" && cwd) {
+    rememberDone({ sessionId, pidChain: pidChain ?? [], cwd });
+  }
+
   if (reason === "done" || reason === "input" || reason === "question") {
     // Stage dedup: at most one notification per (session, reason) per stage.
     // Stage advances on UserPromptSubmit (prompt signal) or idle (30 min).
     if (!stage.shouldFire(sessionId, reason)) {
       return;
     }
-    showNotification(reason);
+    showNotification(reason, cwd);
   }
 
   // doneDebounceMs is deprecated — stage dedup replaces it. Log once so
@@ -95,7 +100,7 @@ function warnDeprecatedSettingOnce(): void {
   }
 }
 
-function showNotification(reason: string): void {
+function showNotification(reason: string, cwd: string): void {
   // Architecture note: "question" and "input" local sounds are played by their
   // respective hook scripts (PreToolUse / PermissionRequest) — not the extension.
   // Only "done" local sounds are played here, because the extension is the
@@ -133,9 +138,15 @@ function showNotification(reason: string): void {
       }
     }
     if (level === LEVELS.SOUND_POPUP || level === LEVELS.POPUP) {
-      vscode.window.showInformationMessage("Claude has finished the task.");
+      vscode.window
+        .showInformationMessage("Claude has finished the task.", "Reveal")
+        .then((pick) => {
+          if (pick === "Reveal") {
+            void revealClaudeTab(getRememberedDone(cwd));
+          }
+        });
       if (!isRemote) {
-        showLocalNotification("Claude has finished the task.");
+        showLocalNotification("Claude has finished the task.", cwd);
       }
     }
   }

--- a/src/signals/parser.ts
+++ b/src/signals/parser.ts
@@ -3,24 +3,28 @@ export interface ParsedSignal {
   /** Session id from Claude Code; null when absent (older hooks or v1 format). */
   sessionId: string | null;
   cwd: string;
+  /**
+   * Ancestor PID chain captured by the Stop hook on macOS/Linux. Used to
+   * identify the originating integrated terminal when a notification is
+   * clicked. Null when absent (Windows, non-Stop hooks, or older deployments).
+   */
+  pidChain: number[] | null;
 }
+
+const PID_CHAIN_RE = /^[0-9]+(,[0-9]+)*$/;
 
 /**
  * Signal formats written by hook scripts:
  *
- * v2 (current): "<reason> <ts> <session_id|-> <cwd?>"
+ * v2 (current): "<reason> <ts> <session_id|-> [<pid_chain_csv>] <cwd?>"
  *   session_id is "-" when missing; cwd is optional.
+ *   pid_chain_csv is comma-separated ancestor PIDs; the parser distinguishes
+ *   it from cwd by shape (digits+commas vs path separator). When absent the
+ *   field is omitted entirely.
  *
  * v1 (legacy): "<reason> <ts> <cwd?>"
  *   No session_id. Still parsed for hooks deployed by an older extension
- *   version. The third token disambiguates: if it parses as a base-10
- *   integer-only timestamp-shape it's v1's cwd-start; if it's a token
- *   with no path separator and no dot it's v2's session_id. We pick a
- *   simpler heuristic: a session id is a single token with no path
- *   separator (/ or \\); a cwd contains a path separator.
- *
- * Both formats: cwd may contain spaces and is the rest of the line after
- * the leading tokens.
+ *   version.
  */
 export function parseSignal(content: string): ParsedSignal {
   const parts = content.split(" ");
@@ -36,13 +40,20 @@ export function parseSignal(content: string): ParsedSignal {
 
   if (isV2) {
     const sessionId = third === "-" ? null : (third ?? null);
-    const cwd = parts.slice(3).join(" ");
-    return { reason, sessionId, cwd };
+    const fourth = parts[3];
+    let pidChain: number[] | null = null;
+    let cwdStart = 3;
+    if (fourth !== undefined && PID_CHAIN_RE.test(fourth)) {
+      pidChain = fourth.split(",").map((s) => Number.parseInt(s, 10));
+      cwdStart = 4;
+    }
+    const cwd = parts.slice(cwdStart).join(" ");
+    return { reason, sessionId, cwd, pidChain };
   }
 
   // v1 fallback: "<reason> <ts> <cwd?>"
   const firstSpace = content.indexOf(" ");
   const secondSpace = firstSpace >= 0 ? content.indexOf(" ", firstSpace + 1) : -1;
   const cwd = secondSpace >= 0 ? content.slice(secondSpace + 1) : "";
-  return { reason, sessionId: null, cwd };
+  return { reason, sessionId: null, cwd, pidChain: null };
 }

--- a/test/hook/lib.click.test.ts
+++ b/test/hook/lib.click.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+
+const { buildClickAction, GENERIC_ACTIVATE } = await import("../../hook/_lib/click");
+
+describe("hook/_lib/click — buildClickAction", () => {
+  it("returns null for an empty cwd", () => {
+    expect(buildClickAction("")).toBeNull();
+    expect(buildClickAction(undefined)).toBeNull();
+  });
+
+  it("writes the cwd to the focus-signal file then brings VS Code forward", () => {
+    const cmd = buildClickAction("/Users/foo/proj");
+    expect(cmd).toContain("printf '%s' '/Users/foo/proj'");
+    expect(cmd).toContain("claude-notifier-focus");
+    expect(cmd).toContain("code '/Users/foo/proj'");
+    expect(cmd).toContain("osascript -e 'tell application \"Visual Studio Code\" to activate'");
+  });
+
+  it("escapes single quotes in the cwd safely", () => {
+    const cmd = buildClickAction("/Users/it's me/proj");
+    expect(cmd).toContain("'/Users/it'\\''s me/proj'");
+  });
+
+  it("uses && / || sequencing so the fallback runs only when `code` is absent", () => {
+    const cmd = buildClickAction("/x")!;
+    expect(cmd).toMatch(/code\s+'\/x'\s+2>\/dev\/null\s+\|\|\s+osascript/);
+  });
+});
+
+describe("hook/_lib/click — GENERIC_ACTIVATE", () => {
+  it("exposes an osascript activate command for callers without a cwd", () => {
+    expect(GENERIC_ACTIVATE).toContain("osascript");
+    expect(GENERIC_ACTIVATE).toContain("Visual Studio Code");
+    expect(GENERIC_ACTIVATE).toContain("activate");
+  });
+});

--- a/test/hook/lib.pid.test.ts
+++ b/test/hook/lib.pid.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+
+const { getAncestorPids } = await import("../../hook/_lib/pid");
+
+describe("hook/_lib/pid — getAncestorPids", () => {
+  it("returns an array", () => {
+    const chain = getAncestorPids();
+    expect(Array.isArray(chain)).toBe(true);
+  });
+
+  it("contains only positive integers", () => {
+    const chain = getAncestorPids();
+    for (const pid of chain) {
+      expect(Number.isInteger(pid)).toBe(true);
+      expect(pid).toBeGreaterThan(1);
+    }
+  });
+
+  it("respects the depth cap", () => {
+    const chain = getAncestorPids(3);
+    expect(chain.length).toBeLessThanOrEqual(3);
+  });
+
+  it("does not contain duplicates", () => {
+    const chain = getAncestorPids();
+    expect(new Set(chain).size).toBe(chain.length);
+  });
+
+  it("returns [] on Windows", () => {
+    if (process.platform !== "win32") return;
+    expect(getAncestorPids()).toEqual([]);
+  });
+});

--- a/test/hook/lib.signal.test.ts
+++ b/test/hook/lib.signal.test.ts
@@ -59,4 +59,26 @@ describe("hook/_lib/signal — writeSignal", () => {
   it("does not throw with valid args", () => {
     expect(() => signal.writeSignal("done", "x", "/cwd")).not.toThrow();
   });
+
+  it("includes pid_chain CSV before cwd when provided", () => {
+    signal.writeSignal("done", "abc", "/Users/foo", [1001, 1002, 1003]);
+    expect(fs.readFileSync(SIGNAL_FILE, "utf-8")).toMatch(
+      /^done \d+ abc 1001,1002,1003 \/Users\/foo$/
+    );
+  });
+
+  it("omits pid_chain when array is empty", () => {
+    signal.writeSignal("done", "abc", "/Users/foo", []);
+    expect(fs.readFileSync(SIGNAL_FILE, "utf-8")).toMatch(/^done \d+ abc \/Users\/foo$/);
+  });
+
+  it("omits pid_chain when undefined", () => {
+    signal.writeSignal("done", "abc", "/Users/foo");
+    expect(fs.readFileSync(SIGNAL_FILE, "utf-8")).toMatch(/^done \d+ abc \/Users\/foo$/);
+  });
+
+  it("filters non-positive and non-integer pids", () => {
+    signal.writeSignal("done", "abc", "/Users/foo", [1001, 0, -5, 1.5, 2002]);
+    expect(fs.readFileSync(SIGNAL_FILE, "utf-8")).toMatch(/^done \d+ abc 1001,2002 \/Users\/foo$/);
+  });
 });

--- a/test/hook/on-stop.test.ts
+++ b/test/hook/on-stop.test.ts
@@ -16,22 +16,24 @@ describe("hook: claude-notifier-on-stop", () => {
   });
   afterEach(() => home.dispose());
 
+  // The pid_chain field is optional in the v2 signal: emitted on macOS/Linux
+  // by the Stop hook, omitted on Windows. Regexes below tolerate both shapes.
   it("writes a v2 'done' signal with session id and cwd", () => {
     const res = runHook(SCRIPT, { session_id: "s-123", cwd: "/Users/foo/proj" }, home.root);
     expect(res.status).toBe(0);
-    expect(readSignal(home.signalFile)).toMatch(/^done \d+ s-123 \/Users\/foo\/proj$/);
+    expect(readSignal(home.signalFile)).toMatch(/^done \d+ s-123( [0-9,]+)? \/Users\/foo\/proj$/);
   });
 
   it("renders missing session id as '-'", () => {
     const res = runHook(SCRIPT, { cwd: "/Users/foo/proj" }, home.root);
     expect(res.status).toBe(0);
-    expect(readSignal(home.signalFile)).toMatch(/^done \d+ - \/Users\/foo\/proj$/);
+    expect(readSignal(home.signalFile)).toMatch(/^done \d+ -( [0-9,]+)? \/Users\/foo\/proj$/);
   });
 
   it("falls back to process.cwd() when input.cwd missing", () => {
     const res = runHook(SCRIPT, { session_id: "s-1" }, home.root);
     expect(res.status).toBe(0);
-    expect(readSignal(home.signalFile)).toMatch(/^done \d+ s-1 \S+/);
+    expect(readSignal(home.signalFile)).toMatch(/^done \d+ s-1( [0-9,]+)? \S+/);
   });
 
   it("stop_hook_active short-circuits before signal write", () => {
@@ -71,7 +73,7 @@ describe("hook: claude-notifier-on-stop", () => {
       home.root
     );
     expect(res.status).toBe(0);
-    expect(readSignal(home.signalFile)).toMatch(/^done \d+ s-1 \/Users\/foo\/proj$/);
+    expect(readSignal(home.signalFile)).toMatch(/^done \d+ s-1( [0-9,]+)? \/Users\/foo\/proj$/);
   });
 
   it("cwd outside any active marker's folder falls through (signal still written)", () => {
@@ -80,7 +82,7 @@ describe("hook: claude-notifier-on-stop", () => {
     // and the hook proceeds to terminal-fallback. Signal still gets written.
     const res = runHook(SCRIPT, { session_id: "s-1", cwd: "/tmp/different" }, home.root);
     expect(res.status).toBe(0);
-    expect(readSignal(home.signalFile)).toMatch(/^done \d+ s-1 \/tmp\/different$/);
+    expect(readSignal(home.signalFile)).toMatch(/^done \d+ s-1( [0-9,]+)? \/tmp\/different$/);
     // No timing assertion — terminal fallback may play sound here.
   });
 });

--- a/test/unit/routing.focus.test.ts
+++ b/test/unit/routing.focus.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import * as vscode from "vscode";
+import {
+  rememberDone,
+  getRememberedDone,
+  resetDoneMemory,
+  revealClaudeTab,
+} from "../../src/routing/focus";
+
+interface FakeTerminal {
+  processId: Promise<number | undefined>;
+  show: ReturnType<typeof vi.fn>;
+}
+
+function fakeTerminal(pid: number | undefined): FakeTerminal {
+  return { processId: Promise.resolve(pid), show: vi.fn() };
+}
+
+describe("routing/focus — done memory", () => {
+  beforeEach(() => resetDoneMemory());
+
+  it("remembers and returns the last done context for a cwd", () => {
+    rememberDone({ sessionId: "abc", pidChain: [1, 2], cwd: "/Users/foo" });
+    expect(getRememberedDone("/Users/foo")).toEqual({
+      sessionId: "abc",
+      pidChain: [1, 2],
+      cwd: "/Users/foo",
+    });
+  });
+
+  it("overwrites prior context for the same cwd", () => {
+    rememberDone({ sessionId: "a", pidChain: [1], cwd: "/x" });
+    rememberDone({ sessionId: "b", pidChain: [2], cwd: "/x" });
+    expect(getRememberedDone("/x")?.sessionId).toBe("b");
+  });
+
+  it("returns null for an unknown cwd", () => {
+    expect(getRememberedDone("/never-set")).toBeNull();
+  });
+
+  it("ignores entries with an empty cwd", () => {
+    rememberDone({ sessionId: "a", pidChain: [1], cwd: "" });
+    expect(getRememberedDone("")).toBeNull();
+  });
+
+  it("resetDoneMemory clears all entries", () => {
+    rememberDone({ sessionId: "a", pidChain: [1], cwd: "/x" });
+    resetDoneMemory();
+    expect(getRememberedDone("/x")).toBeNull();
+  });
+});
+
+describe("routing/focus — revealClaudeTab", () => {
+  beforeEach(() => {
+    (vscode.window as { terminals: unknown[] }).terminals = [];
+    vi.restoreAllMocks();
+  });
+
+  it("returns false for a null context", async () => {
+    expect(await revealClaudeTab(null)).toBe(false);
+  });
+
+  it("matches a terminal whose processId is in the pid chain", async () => {
+    const matchingTerm = fakeTerminal(1002);
+    const otherTerm = fakeTerminal(9999);
+    (vscode.window as { terminals: unknown[] }).terminals = [otherTerm, matchingTerm];
+
+    const result = await revealClaudeTab({
+      sessionId: null,
+      pidChain: [1001, 1002, 1003],
+      cwd: "/x",
+    });
+
+    expect(result).toBe(true);
+    expect(matchingTerm.show).toHaveBeenCalledOnce();
+    expect(otherTerm.show).not.toHaveBeenCalled();
+  });
+
+  it("falls back to claude-vscode.editor.open when no terminal matches", async () => {
+    (vscode.window as { terminals: unknown[] }).terminals = [fakeTerminal(9999)];
+    const spy = vi.spyOn(vscode.commands, "executeCommand").mockResolvedValue(undefined);
+
+    const result = await revealClaudeTab({
+      sessionId: "session-abc",
+      pidChain: [1001, 1002],
+      cwd: "/x",
+    });
+
+    expect(result).toBe(true);
+    expect(spy).toHaveBeenCalledWith("claude-vscode.editor.open", "session-abc");
+  });
+
+  it("skips the editor-open fallback when sessionId is null", async () => {
+    (vscode.window as { terminals: unknown[] }).terminals = [fakeTerminal(9999)];
+    const spy = vi.spyOn(vscode.commands, "executeCommand").mockResolvedValue(undefined);
+
+    const result = await revealClaudeTab({ sessionId: null, pidChain: [1001], cwd: "/x" });
+
+    expect(result).toBe(false);
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("returns false when the editor-open command rejects", async () => {
+    (vscode.window as { terminals: unknown[] }).terminals = [];
+    vi.spyOn(vscode.commands, "executeCommand").mockRejectedValue(new Error("not registered"));
+
+    const result = await revealClaudeTab({ sessionId: "abc", pidChain: [], cwd: "/x" });
+
+    expect(result).toBe(false);
+  });
+
+  it("tries terminals before falling back to the editor command", async () => {
+    const matchingTerm = fakeTerminal(1001);
+    (vscode.window as { terminals: unknown[] }).terminals = [matchingTerm];
+    const spy = vi.spyOn(vscode.commands, "executeCommand").mockResolvedValue(undefined);
+
+    const result = await revealClaudeTab({
+      sessionId: "session-abc",
+      pidChain: [1001],
+      cwd: "/x",
+    });
+
+    expect(result).toBe(true);
+    expect(matchingTerm.show).toHaveBeenCalledOnce();
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("returns false when pid chain is empty and no sessionId", async () => {
+    expect(await revealClaudeTab({ sessionId: null, pidChain: [], cwd: "/x" })).toBe(false);
+  });
+});

--- a/test/unit/signals.parser.test.ts
+++ b/test/unit/signals.parser.test.ts
@@ -2,12 +2,13 @@ import { describe, it, expect } from "vitest";
 import { parseSignal } from "../../src/signals/parser";
 
 describe("parseSignal", () => {
-  describe("v2 format: <reason> <ts> <session_id|-> [cwd]", () => {
+  describe("v2 format: <reason> <ts> <session_id|-> [<pid_chain>] [cwd]", () => {
     it("parses session_id and cwd", () => {
       expect(parseSignal("done 1234 abc-123 /Users/foo/proj")).toEqual({
         reason: "done",
         sessionId: "abc-123",
         cwd: "/Users/foo/proj",
+        pidChain: null,
       });
     });
 
@@ -16,6 +17,7 @@ describe("parseSignal", () => {
         reason: "done",
         sessionId: null,
         cwd: "/Users/foo/proj",
+        pidChain: null,
       });
     });
 
@@ -24,6 +26,7 @@ describe("parseSignal", () => {
         reason: "done",
         sessionId: "abc-123",
         cwd: "/Users/foo/my project/code",
+        pidChain: null,
       });
     });
 
@@ -32,6 +35,7 @@ describe("parseSignal", () => {
         reason: "input",
         sessionId: "abc-123",
         cwd: "",
+        pidChain: null,
       });
     });
 
@@ -40,6 +44,7 @@ describe("parseSignal", () => {
         reason: "prompt",
         sessionId: "abc-123",
         cwd: "",
+        pidChain: null,
       });
     });
 
@@ -48,6 +53,51 @@ describe("parseSignal", () => {
         reason: "done",
         sessionId: "abc-123",
         cwd: "C:\\Users\\foo\\proj",
+        pidChain: null,
+      });
+    });
+  });
+
+  describe("v2 with pid_chain", () => {
+    it("parses a multi-pid chain before cwd", () => {
+      expect(parseSignal("done 1234 abc-123 1001,1002,1003 /Users/foo/proj")).toEqual({
+        reason: "done",
+        sessionId: "abc-123",
+        cwd: "/Users/foo/proj",
+        pidChain: [1001, 1002, 1003],
+      });
+    });
+
+    it("parses a single-pid chain", () => {
+      expect(parseSignal("done 1234 abc 4242 /Users/foo")).toEqual({
+        reason: "done",
+        sessionId: "abc",
+        cwd: "/Users/foo",
+        pidChain: [4242],
+      });
+    });
+
+    it("parses a chain with '-' session_id", () => {
+      expect(parseSignal("done 1234 - 100,200 /Users/foo")).toEqual({
+        reason: "done",
+        sessionId: null,
+        cwd: "/Users/foo",
+        pidChain: [100, 200],
+      });
+    });
+
+    it("does not misdetect a cwd whose first segment looks numeric", () => {
+      const r = parseSignal("done 1234 abc /Users/123/foo");
+      expect(r.cwd).toBe("/Users/123/foo");
+      expect(r.pidChain).toBeNull();
+    });
+
+    it("preserves cwd with spaces after pid_chain", () => {
+      expect(parseSignal("done 1234 abc 100,200 /Users/foo/my project")).toEqual({
+        reason: "done",
+        sessionId: "abc",
+        cwd: "/Users/foo/my project",
+        pidChain: [100, 200],
       });
     });
   });
@@ -58,6 +108,7 @@ describe("parseSignal", () => {
         reason: "done",
         sessionId: null,
         cwd: "/Users/foo/proj",
+        pidChain: null,
       });
     });
 
@@ -66,6 +117,7 @@ describe("parseSignal", () => {
         reason: "input",
         sessionId: null,
         cwd: "",
+        pidChain: null,
       });
     });
 
@@ -74,30 +126,42 @@ describe("parseSignal", () => {
       const r = parseSignal("done 1234 /tmp");
       expect(r.sessionId).toBeNull();
       expect(r.cwd).toBe("/tmp");
+      expect(r.pidChain).toBeNull();
     });
 
     it("disambiguates via path separator: backslash → cwd", () => {
       const r = parseSignal("done 1234 C:\\tmp");
       expect(r.sessionId).toBeNull();
       expect(r.cwd).toBe("C:\\tmp");
+      expect(r.pidChain).toBeNull();
     });
   });
 
   describe("edge cases", () => {
     it("empty input returns empty reason", () => {
-      expect(parseSignal("")).toEqual({ reason: "", sessionId: null, cwd: "" });
+      expect(parseSignal("")).toEqual({
+        reason: "",
+        sessionId: null,
+        cwd: "",
+        pidChain: null,
+      });
     });
 
     it("single-word legacy signal (no timestamp, no cwd)", () => {
-      expect(parseSignal("done")).toEqual({ reason: "done", sessionId: null, cwd: "" });
+      expect(parseSignal("done")).toEqual({
+        reason: "done",
+        sessionId: null,
+        cwd: "",
+        pidChain: null,
+      });
     });
 
     it("reason only with trailing space", () => {
-      // First space exists, second doesn't — degenerate but should not throw.
       const r = parseSignal("done ");
       expect(r.reason).toBe("done");
       expect(r.sessionId).toBeNull();
       expect(r.cwd).toBe("");
+      expect(r.pidChain).toBeNull();
     });
   });
 });


### PR DESCRIPTION
## Summary

All Claude Notifier macOS notifications are now clickable and route correctly:

- **Stop notification click**: focuses the *specific* integrated terminal or editor panel where Claude was running, not just the workspace window. Matches `vscode.window.terminals[].processId` against a captured ancestor PID chain, then falls back to `claude-vscode.editor.open <session_id>` for editor panels.
- **VS Code toast** for `taskCompleted`: gains a **Reveal** action button using the same resolver.
- **Permission and question notifications**: now go through `terminal-notifier` instead of `osascript`, so clicks open VS Code instead of Script Editor. Click runs `code <cwd>` to focus the matching window — falling back to `osascript activate` when the `code` CLI isn't on `PATH`.
- All click handlers also write the firing cwd to `~/.claude/hooks/claude-notifier-focus`; the extension's focus watcher reveals the originating Claude tab when one was previously recorded for that cwd.

Original feature idea for the Stop tab-reveal: [@marco-lavagnino](https://github.com/marco-lavagnino) in #15. Code is a fresh write.

## How it works

### Signal format

`done <ts> <session_id> [<pid_chain_csv>] <cwd>` — pid_chain is optional, only Stop hooks on macOS/Linux emit it. The v2 parser detects pid_chain by shape (`/^[0-9]+(,[0-9]+)*$/`) so cwds whose first segment is numeric aren't misdetected.

### Tab resolution

`src/routing/focus.ts` stores `{sessionId, pidChain, cwd}` per cwd on every done signal and exposes `revealClaudeTab(ctx)`:
1. Walk `vscode.window.terminals`; first one whose `processId` is in the chain calls `terminal.show()`.
2. Otherwise call `claude-vscode.editor.open <session_id>` to reveal the Claude Code editor panel.
3. If neither matches, no-op (the window-level focus from `-execute` is the floor).

### Click delivery

- `terminal-notifier`'s `-execute` runs `printf '%s' '<cwd>' > FOCUS_SIGNAL_FILE; { code '<cwd>' 2>/dev/null || osascript -e 'tell application "Visual Studio Code" to activate'; }`.
- The extension watches `FOCUS_SIGNAL_FILE`; only the window owning the cwd acts.
- VS Code toast button bypasses the file entirely and calls `revealClaudeTab` directly.

### Click action builder

`hook/_lib/click.js` builds the `-execute` shell snippet from cwd, with POSIX single-quote escaping for paths containing apostrophes. Stop / permission / question hooks all use it.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm run format:check` clean
- [x] `npm run test:unit` — 74 passing (16 new across parser + focus)
- [x] `npm run test:hook` — 65 passing (15 new across pid + signal + on-stop + click)
- [x] `npm run smoke` — passing
- [ ] Manual end-to-end on macOS:
  - [ ] Two parallel Claude sessions in two windows: clicking each Stop notification brings the correct window forward
  - [ ] Same window with two Claude editor panels: clicking notification reveals the correct panel
  - [ ] Same window with Claude in an integrated terminal: click reveals the terminal tab
  - [ ] Click on a permission notification — no Script Editor, lands in the right VS Code window
  - [ ] Click on a question notification — no Script Editor, lands in the right VS Code window
  - [ ] Without `terminal-notifier` installed: permission/question fall back to osascript notifications (clicks still open Script Editor — known limitation, surfaced in README); no crash
  - [ ] Without the Anthropic Claude Code extension installed: notifications fire; window-level focus still works