### PR TITLE
feat(extension): add Linux support to playLocalSound

### DIFF
--- a/src/notifications/sound.ts
+++ b/src/notifications/sound.ts
@@ -1,5 +1,5 @@
 import { exec } from "child_process";
-import { IS_WIN } from "../paths";
+import { IS_WIN, IS_LINUX } from "../paths";
 
 export const MACOS_SOUNDS: Record<string, string> = {
   Basso: "/System/Library/Sounds/Basso.aiff",
@@ -29,6 +29,24 @@ export const WIN_SOUNDS: Record<string, string> = {
   "Windows Background": "C:\\Windows\\Media\\Windows Background.wav",
 };
 
+export const LINUX_SOUNDS_DIR = "/usr/share/sounds/freedesktop/stereo";
+export const LINUX_SOUNDS: Record<string, string> = {
+  Basso: `${LINUX_SOUNDS_DIR}/dialog-warning.oga`,
+  Blow: `${LINUX_SOUNDS_DIR}/service-logout.oga`,
+  Bottle: `${LINUX_SOUNDS_DIR}/bell.oga`,
+  Frog: `${LINUX_SOUNDS_DIR}/message-new-instant.oga`,
+  Funk: `${LINUX_SOUNDS_DIR}/message-new-instant.oga`,
+  Glass: `${LINUX_SOUNDS_DIR}/bell.oga`,
+  Hero: `${LINUX_SOUNDS_DIR}/complete.oga`,
+  Morse: `${LINUX_SOUNDS_DIR}/message.oga`,
+  Ping: `${LINUX_SOUNDS_DIR}/message.oga`,
+  Pop: `${LINUX_SOUNDS_DIR}/dialog-information.oga`,
+  Purr: `${LINUX_SOUNDS_DIR}/service-login.oga`,
+  Sosumi: `${LINUX_SOUNDS_DIR}/dialog-warning.oga`,
+  Submarine: `${LINUX_SOUNDS_DIR}/alarm-clock-elapsed.oga`,
+  Tink: `${LINUX_SOUNDS_DIR}/bell.oga`,
+};
+
 export function playLocalSound(soundName: string, defaultMac: string, defaultWin: string): void {
   if (IS_WIN) {
     const soundPath = WIN_SOUNDS[soundName] || defaultWin;
@@ -37,6 +55,14 @@ export function playLocalSound(soundName: string, defaultMac: string, defaultWin
       `powershell -NoProfile -NonInteractive -EncodedCommand ${Buffer.from(ps, "utf16le").toString("base64")}`,
       { timeout: 5000 }
     );
+  } else if (IS_LINUX) {
+    // paplay (PulseAudio/PipeWire) preferred; aplay (ALSA) as fallback.
+    // Mirrors the hook-side logic in hook/_lib/play.js so terminal + extension
+    // playback stay in sync on Linux.
+    const soundPath = LINUX_SOUNDS[soundName] || `${LINUX_SOUNDS_DIR}/complete.oga`;
+    exec(`paplay "${soundPath}" 2>/dev/null || aplay "${soundPath}" 2>/dev/null`, {
+      timeout: 5000,
+    });
   } else {
     const soundPath = MACOS_SOUNDS[soundName] || defaultMac;
     exec(`afplay "${soundPath}"`);

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -17,4 +17,5 @@ export const OWN_PID_FILE = path.join(ACTIVE_DIR, String(process.pid));
 
 export const IS_WIN = process.platform === "win32";
 export const IS_MAC = process.platform === "darwin";
+export const IS_LINUX = process.platform === "linux";
 export const HOOK_EXT = IS_WIN ? ".ps1" : ".js";


### PR DESCRIPTION
## Summary

Follow-up to #13. That PR added Linux support to the hook scripts so terminal-only sessions now get sound on Linux via `paplay`/`aplay`. But when the extension owns the CWD (`extensionOwnsCwd()` returns true), playback is handled by `playLocalSound()` in `src/notifications/sound.ts`, which only branches on `IS_WIN` and otherwise falls through to `afplay`. On Linux that exec silently fails, so Linux users hear nothing while VSCode is focused.

This PR brings the extension to parity with the hook scripts.

## Changes

- `src/paths.ts`: export `IS_LINUX`.
- `src/notifications/sound.ts`:
  - Add `LINUX_SOUNDS_DIR` + `LINUX_SOUNDS` map. The mapping is copied verbatim from `hook/_lib/sounds.js` so a given preset name (`Hero`, `Glass`, etc.) resolves to the same freedesktop sound whether the hook or the extension plays it.
  - Branch `playLocalSound()` on `IS_LINUX` and invoke `paplay "<sound>" 2>/dev/null || aplay "<sound>" 2>/dev/null`, mirroring `hook/_lib/play.js`.

The macOS branch is untouched (still the default `else`).

## Why this matters

Without this fix, Linux users have to keep manual `paplay` commands in `~/.claude/settings.json` to cover the VSCode-active case, even with #13 merged. With this PR, the extension handles Linux audio natively and those workarounds can be removed.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm run format:check` clean
- [x] `npm run compile` produces a Linux branch in `out/notifications/sound.js`
- [ ] Manual: install the resulting `.vsix` on Linux, remove any custom `paplay` hooks, confirm sound plays on task completion / permission requests / questions while VSCode is focused
- [ ] Unit tests (`test/unit`) — none exist for `sound.ts` yet; happy to add one in a follow-up if you'd like the platform branches mocked