### PR TITLE
feat: add configurable sound volume

### DIFF
--- a/hook/_lib/play.js
+++ b/hook/_lib/play.js
@@ -2,6 +2,13 @@ const fs = require("fs");
 const { execSync } = require("child_process");
 const { USE_WIN, IS_LINUX, PS_BIN } = require("./platform");
 
+function clampVolume(v) {
+  if (typeof v !== "number" || !Number.isFinite(v)) return 1;
+  if (v < 0) return 0;
+  if (v > 2) return 2;
+  return v;
+}
+
 /**
  * Play a sound file using the platform-native player. Silently swallows errors
  * — sound failure should never break a hook.
@@ -10,11 +17,15 @@ const { USE_WIN, IS_LINUX, PS_BIN } = require("./platform");
  * @param {string} [fallbackPath]  Bundled fallback played when primary doesn't
  *   exist on disk — covers Linux without sound-theme-freedesktop installed,
  *   cross-platform misconfig, removed system sounds, etc.
+ * @param {number} [volume=1]  Volume multiplier (0–2). 1 = system default.
+ *   Honored on Linux (paplay) and macOS (afplay). Windows ignores it because
+ *   Media.SoundPlayer has no volume API.
  */
-function playSound(primaryPath, fallbackPath) {
+function playSound(primaryPath, fallbackPath, volume = 1) {
   const soundPath =
     primaryPath && fs.existsSync(primaryPath) ? primaryPath : fallbackPath || primaryPath;
   if (!soundPath) return;
+  const v = clampVolume(volume);
   try {
     if (USE_WIN) {
       const ps = `$s='${soundPath}'; if(Test-Path $s){(New-Object Media.SoundPlayer $s).PlaySync()}else{[console]::Beep(800,300)}`;
@@ -23,13 +34,14 @@ function playSound(primaryPath, fallbackPath) {
         { stdio: "ignore", timeout: 5000 }
       );
     } else if (IS_LINUX) {
-      // paplay (PulseAudio/PipeWire) preferred; aplay (ALSA) as fallback.
-      execSync(`paplay "${soundPath}" 2>/dev/null || aplay "${soundPath}" 2>/dev/null`, {
-        stdio: "ignore",
-        timeout: 5000,
-      });
+      // paplay --volume uses a 16-bit scale where 65536 = 100%.
+      const paVolume = Math.round(v * 65536);
+      execSync(
+        `paplay --volume=${paVolume} "${soundPath}" 2>/dev/null || aplay "${soundPath}" 2>/dev/null`,
+        { stdio: "ignore", timeout: 5000 }
+      );
     } else {
-      execSync(`afplay "${soundPath}"`, { stdio: "ignore" });
+      execSync(`afplay -v ${v} "${soundPath}"`, { stdio: "ignore" });
     }
   } catch {}
 }

--- a/hook/claude-notifier-on-notification.js
+++ b/hook/claude-notifier-on-notification.js
@@ -3,7 +3,7 @@
 // Plays the "needs input" sound when Claude posts a permission_prompt
 // notification. Uses fixed sound (not config-driven) — this hook fires
 // before the PermissionRequest hook can react.
-const { isMuted } = require("./_lib/config");
+const { isMuted, readConfig } = require("./_lib/config");
 const { resolveSound, BUNDLED_FALLBACK } = require("./_lib/sounds");
 const { playSound } = require("./_lib/play");
 const { showNotification } = require("./_lib/notify");
@@ -30,7 +30,8 @@ process.stdin.on("end", () => {
     "/System/Library/Sounds/Glass.aiff",
     "C:\\Windows\\Media\\Windows Notify.wav"
   );
-  playSound(sound, BUNDLED_FALLBACK.needsPermission);
+  const volume = readConfig()?.soundVolume ?? 1;
+  playSound(sound, BUNDLED_FALLBACK.needsPermission, volume);
 
   const message = input.message || "Claude needs your permission.";
   showNotification(message);

--- a/hook/claude-notifier-on-permission.js
+++ b/hook/claude-notifier-on-permission.js
@@ -24,8 +24,10 @@ process.stdin.on("end", () => {
   // AskUserQuestion is handled by the separate PreToolUse question hook.
   if (input.tool_name === "AskUserQuestion") process.exit(0);
 
-  const cfg = readConfig()?.needsPermission ?? {};
+  const config = readConfig();
+  const cfg = config?.needsPermission ?? {};
   const level = cfg.level ?? "sound+popup";
+  const volume = config?.soundVolume ?? 1;
 
   if (level === "off") process.exit(0);
 
@@ -35,7 +37,7 @@ process.stdin.on("end", () => {
       "/System/Library/Sounds/Glass.aiff",
       "C:\\Windows\\Media\\Windows Notify.wav"
     );
-    playSound(sound, BUNDLED_FALLBACK.needsPermission);
+    playSound(sound, BUNDLED_FALLBACK.needsPermission, volume);
   }
 
   if (level === "sound+popup" || level === "popup") {

--- a/hook/claude-notifier-on-question.js
+++ b/hook/claude-notifier-on-question.js
@@ -24,8 +24,10 @@ process.stdin.on("end", () => {
 
   if (isMuted()) process.exit(0);
 
-  const cfg = readConfig()?.asksQuestion ?? {};
+  const config = readConfig();
+  const cfg = config?.asksQuestion ?? {};
   const level = cfg.level ?? "sound+popup";
+  const volume = config?.soundVolume ?? 1;
 
   if (level === "off") process.exit(0);
 
@@ -35,7 +37,7 @@ process.stdin.on("end", () => {
       "/System/Library/Sounds/Funk.aiff",
       "C:\\Windows\\Media\\Windows Notify.wav"
     );
-    playSound(sound, BUNDLED_FALLBACK.asksQuestion);
+    playSound(sound, BUNDLED_FALLBACK.asksQuestion, volume);
   }
 
   if (level === "sound+popup" || level === "popup") {

--- a/hook/claude-notifier-on-stop.js
+++ b/hook/claude-notifier-on-stop.js
@@ -35,8 +35,10 @@ process.stdin.on("end", () => {
   // with debounce. Otherwise fall through to direct playback.
   if (extensionOwnsCwd(cwd)) process.exit(0);
 
-  const cfg = readConfig()?.taskCompleted ?? {};
+  const config = readConfig();
+  const cfg = config?.taskCompleted ?? {};
   const level = cfg.level ?? "sound+popup";
+  const volume = config?.soundVolume ?? 1;
 
   if (level === "off") process.exit(0);
 
@@ -46,7 +48,7 @@ process.stdin.on("end", () => {
       "/System/Library/Sounds/Hero.aiff",
       "C:\\Windows\\Media\\tada.wav"
     );
-    playSound(sound, BUNDLED_FALLBACK.taskCompleted);
+    playSound(sound, BUNDLED_FALLBACK.taskCompleted, volume);
   }
 
   if (level === "sound+popup" || level === "popup") {

--- a/package.json
+++ b/package.json
@@ -171,6 +171,13 @@
           "default": "Funk",
           "description": "Sound preset when Claude asks a question. macOS: Basso–Tink. Windows: Windows Notify–Windows Background."
         },
+        "claudeNotifier.soundVolume": {
+          "type": "number",
+          "default": 1,
+          "minimum": 0,
+          "maximum": 2,
+          "description": "Volume multiplier applied to all notification sounds. 1 = system default, 2 = boosted (~200%). Honored on Linux (paplay) and macOS (afplay). Windows ignores this — Media.SoundPlayer has no volume API."
+        },
         "claudeNotifier.doneDebounceMs": {
           "type": "number",
           "default": 2000,

--- a/src/notifications/sound.ts
+++ b/src/notifications/sound.ts
@@ -1,5 +1,6 @@
 import { exec } from "child_process";
 import { IS_WIN, IS_LINUX } from "../paths";
+import { clampVolume, DEFAULT_VOLUME } from "../settings/sync";
 
 export const MACOS_SOUNDS: Record<string, string> = {
   Basso: "/System/Library/Sounds/Basso.aiff",
@@ -47,18 +48,11 @@ export const LINUX_SOUNDS: Record<string, string> = {
   Tink: `${LINUX_SOUNDS_DIR}/bell.oga`,
 };
 
-function clampVolume(v: number | undefined): number {
-  if (v === undefined || !Number.isFinite(v)) return 1;
-  if (v < 0) return 0;
-  if (v > 2) return 2;
-  return v;
-}
-
 export function playLocalSound(
   soundName: string,
   defaultMac: string,
   defaultWin: string,
-  volume: number = 1
+  volume: number = DEFAULT_VOLUME
 ): void {
   const v = clampVolume(volume);
   if (IS_WIN) {

--- a/src/notifications/sound.ts
+++ b/src/notifications/sound.ts
@@ -47,8 +47,22 @@ export const LINUX_SOUNDS: Record<string, string> = {
   Tink: `${LINUX_SOUNDS_DIR}/bell.oga`,
 };
 
-export function playLocalSound(soundName: string, defaultMac: string, defaultWin: string): void {
+function clampVolume(v: number | undefined): number {
+  if (v === undefined || !Number.isFinite(v)) return 1;
+  if (v < 0) return 0;
+  if (v > 2) return 2;
+  return v;
+}
+
+export function playLocalSound(
+  soundName: string,
+  defaultMac: string,
+  defaultWin: string,
+  volume: number = 1
+): void {
+  const v = clampVolume(volume);
   if (IS_WIN) {
+    // Media.SoundPlayer has no volume control; volume is ignored on Windows.
     const soundPath = WIN_SOUNDS[soundName] || defaultWin;
     const ps = `$s='${soundPath}'; if(Test-Path $s){(New-Object Media.SoundPlayer $s).PlaySync()}else{[console]::Beep(800,300)}`;
     exec(
@@ -56,15 +70,17 @@ export function playLocalSound(soundName: string, defaultMac: string, defaultWin
       { timeout: 5000 }
     );
   } else if (IS_LINUX) {
-    // paplay (PulseAudio/PipeWire) preferred; aplay (ALSA) as fallback.
-    // Mirrors the hook-side logic in hook/_lib/play.js so terminal + extension
-    // playback stay in sync on Linux.
+    // paplay --volume uses a 16-bit scale where 65536 = 100%. aplay has no
+    // matching flag, so the fallback path plays at system volume.
     const soundPath = LINUX_SOUNDS[soundName] || `${LINUX_SOUNDS_DIR}/complete.oga`;
-    exec(`paplay "${soundPath}" 2>/dev/null || aplay "${soundPath}" 2>/dev/null`, {
-      timeout: 5000,
-    });
+    const paVolume = Math.round(v * 65536);
+    exec(
+      `paplay --volume=${paVolume} "${soundPath}" 2>/dev/null || aplay "${soundPath}" 2>/dev/null`,
+      { timeout: 5000 }
+    );
   } else {
+    // afplay -v takes a 0.0–2.0+ multiplier (1.0 = system volume).
     const soundPath = MACOS_SOUNDS[soundName] || defaultMac;
-    exec(`afplay "${soundPath}"`);
+    exec(`afplay -v ${v} "${soundPath}"`);
   }
 }

--- a/src/settings/sync.ts
+++ b/src/settings/sync.ts
@@ -4,9 +4,18 @@ import { HOOKS_DIR, CONFIG_FILE } from "../paths";
 import { HOOKS } from "../hooks/registry";
 import { LEVELS } from "../signals/types";
 
+export const DEFAULT_VOLUME = 1;
+
+function clampVolume(v: number): number {
+  if (!Number.isFinite(v)) return DEFAULT_VOLUME;
+  if (v < 0) return 0;
+  if (v > 2) return 2;
+  return v;
+}
+
 export function syncConfig(): void {
   const cfg = vscode.workspace.getConfiguration("claudeNotifier");
-  const config = Object.fromEntries(
+  const events = Object.fromEntries(
     HOOKS.map((hook) => [
       hook.eventKey,
       {
@@ -15,6 +24,10 @@ export function syncConfig(): void {
       },
     ])
   );
+  const config = {
+    ...events,
+    soundVolume: clampVolume(cfg.get<number>("soundVolume", DEFAULT_VOLUME)),
+  };
   try {
     fs.mkdirSync(HOOKS_DIR, { recursive: true });
     fs.writeFileSync(CONFIG_FILE, JSON.stringify(config, null, 2) + "\n");
@@ -35,4 +48,13 @@ export function getEventConfig(eventKey: string): { level: string; sound: string
 
 export function getEventLevel(eventKey: string): string {
   return getEventConfig(eventKey).level;
+}
+
+export function getSoundVolume(): number {
+  try {
+    const config = JSON.parse(fs.readFileSync(CONFIG_FILE, "utf-8"));
+    return clampVolume(config.soundVolume ?? DEFAULT_VOLUME);
+  } catch {
+    return DEFAULT_VOLUME;
+  }
 }

--- a/src/settings/sync.ts
+++ b/src/settings/sync.ts
@@ -5,11 +5,13 @@ import { HOOKS } from "../hooks/registry";
 import { LEVELS } from "../signals/types";
 
 export const DEFAULT_VOLUME = 1;
+export const MIN_VOLUME = 0;
+export const MAX_VOLUME = 2;
 
-function clampVolume(v: number): number {
-  if (!Number.isFinite(v)) return DEFAULT_VOLUME;
-  if (v < 0) return 0;
-  if (v > 2) return 2;
+export function clampVolume(v: number | undefined): number {
+  if (v === undefined || !Number.isFinite(v)) return DEFAULT_VOLUME;
+  if (v < MIN_VOLUME) return MIN_VOLUME;
+  if (v > MAX_VOLUME) return MAX_VOLUME;
   return v;
 }
 

--- a/src/signals/dispatch.ts
+++ b/src/signals/dispatch.ts
@@ -7,7 +7,7 @@ import * as stage from "./stage";
 import { log } from "../log";
 import { getOwnWorkspaceFolders, cwdMatchesFolder } from "../routing/cwd";
 import { rememberDone, getRememberedDone, revealClaudeTab } from "../routing/focus";
-import { getEventLevel, getEventConfig } from "../settings/sync";
+import { getEventLevel, getEventConfig, getSoundVolume } from "../settings/sync";
 import { playLocalSound } from "../notifications/sound";
 import { showLocalNotification } from "../notifications/local";
 import { playRemoteSound } from "../notifications/remote";
@@ -133,7 +133,8 @@ function showNotification(reason: string, cwd: string): void {
         playLocalSound(
           cfg.sound,
           "/System/Library/Sounds/Hero.aiff",
-          "C:\\Windows\\Media\\tada.wav"
+          "C:\\Windows\\Media\\tada.wav",
+          getSoundVolume()
         );
       }
     }


### PR DESCRIPTION
## Summary

Adds a global `claudeNotifier.soundVolume` setting (0–2, default 1) honored by both the extension's `playLocalSound()` and the hook scripts' `playSound()`. Lets users boost (or quiet) all notification sounds without editing `~/.claude/settings.json` with manual `paplay`/`afplay` wrappers.

> **Depends on #37** for the Linux branch in `playLocalSound()` / `playSound()`. The diff in this PR adds `--volume`/`-v` to those branches; if #37 isn't merged first, GitHub will show a conflict on `src/notifications/sound.ts` and `hook/_lib/play.js`. Easiest order: merge #37, then this.

## Per-platform behavior

| Platform | Player           | How volume is applied                            |
| -------- | ---------------- | ------------------------------------------------ |
| Linux    | `paplay`         | `--volume=<v*65536>` (16-bit scale, 65536 = 100%) |
| macOS    | `afplay`         | `-v <v>` (1.0 = system volume)                   |
| Windows  | `Media.SoundPlayer` | Ignored — no volume API. Documented in the setting description. |

`aplay` (Linux fallback when paplay is missing) has no equivalent flag, so it plays at system volume.

## Changes

- `package.json`: new `claudeNotifier.soundVolume` (number, min 0, max 2, default 1).
- `src/settings/sync.ts`: `syncConfig()` now writes `soundVolume` alongside the per-event `{level, sound}` entries. New `getSoundVolume()` reads it back with a clamp.
- `src/notifications/sound.ts`: `playLocalSound(soundName, defaultMac, defaultWin, volume?)`. Volume defaults to 1, so existing callers are unaffected.
- `src/signals/dispatch.ts`: passes `getSoundVolume()` to the done-event `playLocalSound` call.
- `hook/_lib/play.js`: `playSound(primaryPath, fallbackPath, volume?)` with matching platform branches.
- `hook/claude-notifier-on-{stop,permission,question,notification}.js`: read `soundVolume` from the hook config file and forward it.

PowerShell hooks (`_lib.ps1` + `.ps1` entry points) use the same `Media.SoundPlayer` path that the Windows JS branch uses, so no PS changes — Windows volume control would need a separate WAV-decoder/waveOut approach and is out of scope here.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm run format:check` clean
- [x] `npm run compile` — `paplay --volume=...` and `afplay -v ...` present in `out/notifications/sound.js`
- [ ] Manual: install `.vsix` on Linux, set `claudeNotifier.soundVolume` to `2`, confirm sounds are louder (both extension-active and terminal-only paths)
- [ ] Manual: same on macOS (`afplay -v 2`)
- [ ] Manual: confirm Windows still plays at system volume with no errors