### PR TITLE
fix(focus): stop duplicating the chat tab on notification click

### DIFF
--- a/src/routing/focus.ts
+++ b/src/routing/focus.ts
@@ -26,10 +26,14 @@ export function resetDoneMemory(): void {
 }
 
 /**
- * Reveal the originating Claude session: match the captured ancestor PIDs
- * against integrated terminals first, then fall back to asking the Anthropic
- * Claude Code extension to open the editor panel for the session id.
- * Returns true when something was revealed.
+ * Reveal the originating Claude session by matching the captured ancestor PIDs
+ * against integrated terminals. Returns true when a terminal was revealed.
+ *
+ * Chat (webview) sessions intentionally have no reveal action here: the click
+ * pipeline already brings the VS Code window forward, which shows the open chat.
+ * The Anthropic `claude-vscode.editor.open` command was tried previously but it
+ * opens a *new* tab whenever its in-memory session map misses, duplicating the
+ * already-open chat instead of focusing it.
  */
 export async function revealClaudeTab(ctx: DoneContext | null): Promise<boolean> {
   if (!ctx) return false;
@@ -41,15 +45,6 @@ export async function revealClaudeTab(ctx: DoneContext | null): Promise<boolean>
         term.show();
         return true;
       }
-    }
-  }
-
-  if (ctx.sessionId) {
-    try {
-      await vscode.commands.executeCommand("claude-vscode.editor.open", ctx.sessionId);
-      return true;
-    } catch {
-      // Anthropic Claude Code extension not installed or command not registered.
     }
   }
 

--- a/test/unit/routing.focus.test.ts
+++ b/test/unit/routing.focus.test.ts
@@ -76,7 +76,7 @@ describe("routing/focus — revealClaudeTab", () => {
     expect(otherTerm.show).not.toHaveBeenCalled();
   });
 
-  it("falls back to claude-vscode.editor.open when no terminal matches", async () => {
+  it("never opens a new editor tab when no terminal matches (chat session)", async () => {
     (vscode.window as { terminals: unknown[] }).terminals = [fakeTerminal(9999)];
     const spy = vi.spyOn(vscode.commands, "executeCommand").mockResolvedValue(undefined);
 
@@ -86,30 +86,11 @@ describe("routing/focus — revealClaudeTab", () => {
       cwd: "/x",
     });
 
-    expect(result).toBe(true);
-    expect(spy).toHaveBeenCalledWith("claude-vscode.editor.open", "session-abc");
-  });
-
-  it("skips the editor-open fallback when sessionId is null", async () => {
-    (vscode.window as { terminals: unknown[] }).terminals = [fakeTerminal(9999)];
-    const spy = vi.spyOn(vscode.commands, "executeCommand").mockResolvedValue(undefined);
-
-    const result = await revealClaudeTab({ sessionId: null, pidChain: [1001], cwd: "/x" });
-
     expect(result).toBe(false);
     expect(spy).not.toHaveBeenCalled();
   });
 
-  it("returns false when the editor-open command rejects", async () => {
-    (vscode.window as { terminals: unknown[] }).terminals = [];
-    vi.spyOn(vscode.commands, "executeCommand").mockRejectedValue(new Error("not registered"));
-
-    const result = await revealClaudeTab({ sessionId: "abc", pidChain: [], cwd: "/x" });
-
-    expect(result).toBe(false);
-  });
-
-  it("tries terminals before falling back to the editor command", async () => {
+  it("focuses the terminal without invoking any command", async () => {
     const matchingTerm = fakeTerminal(1001);
     (vscode.window as { terminals: unknown[] }).terminals = [matchingTerm];
     const spy = vi.spyOn(vscode.commands, "executeCommand").mockResolvedValue(undefined);
@@ -125,7 +106,10 @@ describe("routing/focus — revealClaudeTab", () => {
     expect(spy).not.toHaveBeenCalled();
   });
 
-  it("returns false when pid chain is empty and no sessionId", async () => {
+  it("returns false when pid chain is empty", async () => {
+    const spy = vi.spyOn(vscode.commands, "executeCommand").mockResolvedValue(undefined);
+    expect(await revealClaudeTab({ sessionId: "abc", pidChain: [], cwd: "/x" })).toBe(false);
     expect(await revealClaudeTab({ sessionId: null, pidChain: [], cwd: "/x" })).toBe(false);
+    expect(spy).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

Clicking a Claude Notifier "done" notification (banner or in-window **Reveal**) opened a **duplicate** Claude chat tab instead of focusing the already-open one.

`revealClaudeTab` fell back to `claude-vscode.editor.open(sessionId)` for chat (webview) sessions when no integrated terminal matched the captured PID chain. That command only reveals an existing panel when the Anthropic extension's in-memory `sessionPanels` map holds the session id — but its webview serializer restores chat panels after a window reload with `sessionId = undefined`:

```js
deserializeWebviewPanel(A, R) { ... setupPanel(A, void 0, void 0, v) }   // no session id
```

So a restored panel is never re-registered, `editor.open(sessionId)` misses, and a new tab is spawned. This regressed when the click-to-focus feature was reimplemented post-v3.0.0 (#36); pre-3.0.0 clicking simply brought the window forward.

## Fix

Drop the `editor.open` fallback from `revealClaudeTab`:

- **Terminal sessions** still focus via PID match (`terminal.show()`).
- **Chat sessions** rely on the existing window-forward step (`code <folder>`), which surfaces the open chat without duplicating it.

## Known limitation (intentional)

When *another VS Code window* is already frontmost, the originating window won't auto-raise — a VS Code limitation (microsoft/vscode#139215); `code <path>` doesn't reorder windows when the app is already active. Robustly solving it needs OS-level Accessibility permissions; out of scope here.

## Test plan

- [x] `npm test` — 72 unit + 65 hook pass
- [x] `npm run typecheck` clean
- [x] Updated `routing.focus` tests to assert no command is invoked for chat sessions
- [x] Sideloaded build: clicking the notification no longer opens a duplicate chat tab