### PR TITLE
chore(release): 3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,16 @@
 # Changelog
 
-## [Unreleased]
+## [3.1.0] - 2026-05-23
 
 ### Added
 
 - Click-to-focus the originating Claude session. When a Stop notification is clicked (via `terminal-notifier` on macOS) or the **Reveal** action button on the VS Code toast, the extension now reveals the specific integrated terminal or editor panel where Claude was running — not just the workspace window. Implementation: Stop hooks capture the ancestor PID chain on macOS/Linux and send it in the v2 signal; the extension matches a terminal's `processId` against the chain and falls back to `claude-vscode.editor.open <session_id>` for editor panels. Original feature idea by [@marco-lavagnino](https://github.com/marco-lavagnino) in [#15](https://github.com/ashmitb95/claude-notifier/pull/15).
 - Permission and question macOS notifications are now clickable. Previously, clicking either notification opened Script Editor (they were emitted through `osascript`). They now go through `terminal-notifier` like the Stop notification: clicks run `code <cwd>` to focus the matching VS Code window — falling back to `osascript activate` when the `code` CLI isn't on `PATH` — and write the firing cwd to `~/.claude/hooks/claude-notifier-focus` so the focus watcher reveals the originating Claude tab when one was previously recorded.
+- Native Linux sound playback for the extension's own `done` notification. The in-extension `playLocalSound` (used when a VS Code window owns the session's cwd) previously handled only macOS and Windows, so the `done` chime fell silent on Linux; it now uses `paplay` (with `aplay` as fallback) and maps the sound presets to freedesktop sounds, matching the hook-side Linux behavior from 2.4.0. Contributed by [@collectifweb](https://github.com/collectifweb). ([#37](https://github.com/ashmitb95/claude-notifier/pull/37))
+
+### Fixed
+
+- Clicking a `done` notification (the macOS banner or the **Reveal** toast action) no longer opens a duplicate Claude chat tab. The `claude-vscode.editor.open <session_id>` fallback duplicated the tab because the Anthropic extension restores chat panels after a window reload without a session id, so the lookup always missed and a fresh tab was created. Chat sessions now rely on the existing window-forward step; integrated terminals still focus via PID match. ([#39](https://github.com/ashmitb95/claude-notifier/pull/39))
 
 ## [3.0.0] - 2026-05-16
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-notifier",
-  "version": "2.4.0",
+  "version": "3.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-notifier",
-      "version": "2.4.0",
+      "version": "3.1.0",
       "devDependencies": {
         "@eslint/js": "^10.0.1",
         "@types/node": "^20.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "claude-notifier",
   "displayName": "Claude Notifier",
   "description": "Plays distinct sounds when Claude Code finishes a task or needs your input",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "icon": "media/icon.png",
   "publisher": "SingularityInc",
   "repository": {


### PR DESCRIPTION
Release **v3.1.0** — version bump + changelog for everything merged to `main` since v3.0.0.

## Included
- **#36** — clickable macOS notifications + click-to-focus the originating Claude session (idea from #15, @marco-lavagnino)
- **#37** — Linux sound playback in the extension's `done` notification (@collectifweb)
- **#39** — fix: clicking a `done` notification no longer opens a duplicate Claude chat tab

> Excludes the sound-volume PR (#38), which is still in review.

## Changes
- `package.json` / `package-lock.json`: `3.0.0` → `3.1.0` (also corrects the stale `2.4.0` lock version)
- `CHANGELOG.md`: new `[3.1.0] - 2026-05-23` section (Added: #36, #37; Fixed: #39)

## Gates (local)
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm test` (unit + hook)

## After merge
Tag `v3.1.0` + GitHub Release (note: prior releases v2.4.0/v3.0.0 were never tagged). Marketplace publish handled separately.