### PR TITLE
chore(release): 3.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [3.2.0] - 2026-05-23
+
+### Added
+
+- Configurable sound volume via a global `claudeNotifier.soundVolume` setting (0–2, default 1), honored by both the extension's `playLocalSound()` and the hook scripts' `playSound()`. Applied through `paplay --volume` on Linux and `afplay -v` on macOS; Windows plays at system volume (`Media.SoundPlayer` exposes no volume API). Contributed by [@collectifweb](https://github.com/collectifweb). ([#38](https://github.com/ashmitb95/claude-notifier/pull/38))
+
 ## [3.1.0] - 2026-05-23
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-notifier",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-notifier",
-      "version": "3.1.0",
+      "version": "3.2.0",
       "devDependencies": {
         "@eslint/js": "^10.0.1",
         "@types/node": "^20.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "claude-notifier",
   "displayName": "Claude Notifier",
   "description": "Plays distinct sounds when Claude Code finishes a task or needs your input",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "icon": "media/icon.png",
   "publisher": "SingularityInc",
   "repository": {


### PR DESCRIPTION
Release **v3.2.0** — version bump + changelog for #38, merged to `main` since v3.1.0.

## Included
- **#38** — configurable sound volume (`claudeNotifier.soundVolume`, 0–2, default 1) honored by the extension and the hooks; `paplay --volume` (Linux), `afplay -v` (macOS), system volume on Windows. (@collectifweb)

## Changes
- `package.json` / `package-lock.json`: `3.1.0` → `3.2.0`
- `CHANGELOG.md`: new `[3.2.0] - 2026-05-23` section

## Gates (local)
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm test` (unit + hook)

## After merge
Tag `v3.2.0` + GitHub Release with the built `.vsix`.