### PR TITLE
fix: suppress duplicate sound/popup inside cmux

### DIFF
--- a/hook/_lib/cmux.js
+++ b/hook/_lib/cmux.js
@@ -1,0 +1,21 @@
+// Detect whether this hook is running under a cmux-managed Claude session.
+//
+// cmux (com.cmuxterm.app) launches Claude through a wrapper that injects its
+// own Stop / Notification / PermissionRequest hooks, which post cmux's native
+// banners. When those are active, claude-notifier must not also play a sound or
+// show a popup — that double-notifies the user. This is the same "defer to a
+// host that has its own notifications" rule the Stop hook already applies for
+// VS Code via extensionOwnsCwd().
+//
+// We gate on CMUX_CLAUDE_HOOK_CMUX_BIN specifically (not CMUX_BUNDLE_ID): the
+// cmux wrapper exports it only after it has decided to inject its hooks, so its
+// presence is an exact signal that cmux is posting its own notifications. A
+// plain cmux pane with hooks disabled (CMUX_CLAUDE_HOOKS_DISABLED=1) leaves it
+// unset, so claude-notifier still fires there.
+//
+// Only user-facing sound/popup output is gated; signal writing is unaffected.
+function isInsideCmux() {
+  return !!process.env.CMUX_CLAUDE_HOOK_CMUX_BIN;
+}
+
+module.exports = { isInsideCmux };

--- a/hook/_lib/notify.js
+++ b/hook/_lib/notify.js
@@ -1,6 +1,7 @@
 const fs = require("fs");
 const { execSync, execFileSync } = require("child_process");
 const { USE_WIN, IS_LINUX, IS_MAC, PS_BIN } = require("./platform");
+const { isInsideCmux } = require("./cmux");
 
 const TITLE = "Claude Notifier";
 
@@ -43,6 +44,9 @@ function findTerminalNotifier() {
  * can't carry a click action; their click defaults to Script Editor).
  */
 function showNotification(message, opts = {}) {
+  // cmux posts its own banner for the same event; skip the popup to avoid
+  // double-notifying. See _lib/cmux.js.
+  if (isInsideCmux()) return;
   const preferTn = !!opts.preferTerminalNotifier;
   const executeCmd = opts.executeCmd;
   try {

--- a/hook/_lib/play.js
+++ b/hook/_lib/play.js
@@ -1,6 +1,7 @@
 const fs = require("fs");
 const { execSync } = require("child_process");
 const { USE_WIN, IS_LINUX, PS_BIN } = require("./platform");
+const { isInsideCmux } = require("./cmux");
 
 function clampVolume(v) {
   if (typeof v !== "number" || !Number.isFinite(v)) return 1;
@@ -22,6 +23,9 @@ function clampVolume(v) {
  *   Media.SoundPlayer has no volume API.
  */
 function playSound(primaryPath, fallbackPath, volume = 1) {
+  // cmux posts its own banner for the same event; skip the sound to avoid
+  // double-notifying. See _lib/cmux.js.
+  if (isInsideCmux()) return;
   const soundPath =
     primaryPath && fs.existsSync(primaryPath) ? primaryPath : fallbackPath || primaryPath;
   if (!soundPath) return;

--- a/test/hook/lib.cmux.test.ts
+++ b/test/hook/lib.cmux.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, afterEach } from "vitest";
+
+// isInsideCmux() reads process.env at call time, so a single import is fine.
+const { isInsideCmux } = await import("../../hook/_lib/cmux");
+
+const VAR = "CMUX_CLAUDE_HOOK_CMUX_BIN";
+const ORIG = process.env[VAR];
+
+function restore() {
+  if (ORIG === undefined) delete process.env[VAR];
+  else process.env[VAR] = ORIG;
+}
+
+describe("hook/_lib/cmux — isInsideCmux", () => {
+  afterEach(restore);
+
+  it("true when CMUX_CLAUDE_HOOK_CMUX_BIN is set (cmux injected its hooks)", () => {
+    process.env[VAR] = "/Applications/cmux.app/Contents/Resources/bin/cmux";
+    expect(isInsideCmux()).toBe(true);
+  });
+
+  it("false when CMUX_CLAUDE_HOOK_CMUX_BIN is unset", () => {
+    delete process.env[VAR];
+    expect(isInsideCmux()).toBe(false);
+  });
+
+  it("false when the var is empty (a bare cmux pane with hooks disabled)", () => {
+    process.env[VAR] = "";
+    expect(isInsideCmux()).toBe(false);
+  });
+});

--- a/test/hook/on-permission.test.ts
+++ b/test/hook/on-permission.test.ts
@@ -20,6 +20,16 @@ describe("hook: claude-notifier-on-permission", () => {
     expect(readSignal(home.signalFile)).toMatch(/^input \d+ s-1$/);
   });
 
+  it("inside cmux: still writes the 'input' signal (notification suppressed by the cmux guard)", () => {
+    // cmux injects its own hooks that post a native banner, so the cmux guard
+    // skips claude-notifier's sound/popup. Signal coordination must survive.
+    const res = runHook(SCRIPT, { tool_name: "Bash", session_id: "s-1" }, home.root, {
+      extraEnv: { CMUX_CLAUDE_HOOK_CMUX_BIN: "/Applications/cmux.app/Contents/Resources/bin/cmux" },
+    });
+    expect(res.status).toBe(0);
+    expect(readSignal(home.signalFile)).toMatch(/^input \d+ s-1$/);
+  });
+
   it("AskUserQuestion is skipped (handled by the question hook)", () => {
     const res = runHook(SCRIPT, { tool_name: "AskUserQuestion", session_id: "s-1" }, home.root);
     expect(res.status).toBe(0);


### PR DESCRIPTION
## Summary

First off, thank you for this extension — it's become part of my daily Claude
Code workflow, and the terminal-fallback design is what makes it work so nicely
outside VS Code. This is a small fix to make it play well in one more place.

Inside [cmux](https://github.com/manaflow-ai/cmux) (`com.cmuxterm.app`), every task
completion and permission request produced **two** notifications: cmux's own
banner *and* claude-notifier's sound/popup.

cmux launches Claude through a wrapper that injects its own
`Stop` / `Notification` / `PermissionRequest` hooks (which post cmux's native
banners). Because claude-notifier's hooks live in the global `settings.json`,
they fire in the same session too — so the user gets notified twice.

This adds `hook/_lib/cmux.js` (`isInsideCmux()`) and gates `playSound()` and
`showNotification()` on it, so claude-notifier stays silent when cmux is
already notifying. It's the same "defer to a host that has its own
notifications" rule the Stop hook already applies to VS Code via
`extensionOwnsCwd()` — cmux just joins VS Code in that category. The
terminal-fallback path for plain terminals (iTerm, Terminal.app, Ghostty, …)
is unchanged, and `writeSignal()` is untouched so extension coordination still
works.

Detection gates on `CMUX_CLAUDE_HOOK_CMUX_BIN`: cmux's
[`claude` wrapper](https://github.com/manaflow-ai/cmux/blob/main/Resources/bin/claude)
exports it only when it actually injects its own hooks, so its presence is a
precise signal that cmux is notifying. With hooks disabled
(`CMUX_CLAUDE_HOOKS_DISABLED=1`) it stays unset, so claude-notifier still fires.

## Test plan

- [x] `npm test` green locally — added `test/hook/lib.cmux.test.ts` (the helper)
  and an `on-permission` case proving the signal is still written under the cmux
  env. Ran the full suite **both** with the cmux env set and with it unset
  (`env -u CMUX_CLAUDE_HOOK_CMUX_BIN -u CMUX_BUNDLE_ID npm test`) — green both ways.
- [x] `npm run typecheck && npm run lint && npm run format:check` green
- [x] `npm run smoke` green (macOS)

## Notes for reviewer

- **Placement.** The guard lives in `_lib/playSound`/`showNotification` rather
  than in each hook, so it covers `stop` / `notification` / `permission` /
  `question` in one place and is independent of where each hook calls
  `writeSignal()` — signal coordination is never affected.
- **Windows/PowerShell hooks are intentionally untouched** — cmux is macOS-only,
  so the `.ps1` path can't be in a cmux session.
- **Scope.** This fixes the notifications the hooks spawn directly. The
  extension-side signal pipeline (`src/signals/`, cwd routing) is unchanged; if a
  cmux session's cwd happens to be owned by an open VS Code window, that's a
  separate path and out of scope for this PR.
