### PR TITLE
fix(install): add missing _lib modules and fix uninstall hook cleanup

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -26,7 +26,7 @@ for script in claude-notifier-on-stop.js claude-notifier-on-permission.js claude
 done
 
 # Shared hook library (required by the hook scripts since v3.0)
-for lib in platform.js paths.js sounds.js config.js play.js notify.js signal.js active.js; do
+for lib in platform.js paths.js sounds.js config.js play.js notify.js signal.js active.js pid.js click.js task-timer.js cmux.js; do
   curl -fsSL "$REPO_RAW/hook/_lib/$lib" -o "$HOOKS_DIR/_lib/$lib"
 done
 

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -22,7 +22,7 @@ if [ -f "$SETTINGS_FILE" ]; then
   node -e "
 const fs = require('fs');
 const settings = JSON.parse(fs.readFileSync('$SETTINGS_FILE', 'utf-8'));
-for (const t of ['Stop', 'PermissionRequest', 'PreToolUse', 'Notification']) {
+for (const t of ['Stop', 'PermissionRequest', 'PreToolUse', 'Notification', 'UserPromptSubmit']) {
   if (settings.hooks?.[t]) {
     settings.hooks[t] = settings.hooks[t].filter(
       e => !e.hooks?.some(h => h.command?.includes('claude-notifier'))


### PR DESCRIPTION
Fixes #50

## Changes

### install.sh
Added 4 missing `_lib` modules to the installer copy list:
- `pid.js` — required by `claude-notifier-on-stop.js`
- `click.js` — required by on-stop / on-permission / on-question
- `task-timer.js` — required by all four `on-*` hooks
- `cmux.js` — required by `_lib/play.js` and `_lib/notify.js` (transitive)

Without these, every hook crashes immediately after a fresh install (e.g. `Cannot find module './cmux'`).

### uninstall.sh
Added `UserPromptSubmit` to the hook cleanup event list. The install script registers a `UserPromptSubmit` hook but the uninstaller was not removing it, leaving a dangling hook registration behind.
