### PR TITLE
fix(install): derive _lib list from repo + uninstall UserPromptSubmit hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [3.3.1] - 2026-06-05
+
+### Fixed
+
+- **`install.sh` no longer ships a broken install.** The installer copied a hardcoded list of `_lib` modules that had silently rotted — `pid.js`, `click.js`, `task-timer.js`, and `cmux.js` were all required by the hooks but missing from the list, so a fresh `curl | bash` install crashed every event hook (e.g. `Cannot find module './cmux'`). The list is now derived from the repo via the GitHub contents API, so it can't drift again as new modules are added. ([#50](https://github.com/ashmitb95/claude-notifier/issues/50))
+- **`uninstall.sh` now removes the `UserPromptSubmit` hook.** `install.sh` registers a `UserPromptSubmit` hook but the uninstaller never removed it, leaving a dangling registration behind. ([#50](https://github.com/ashmitb95/claude-notifier/issues/50))
+
 ## [3.3.0] - 2026-05-24
 
 ### Added

--- a/install.sh
+++ b/install.sh
@@ -15,6 +15,7 @@ CLAUDE_DIR="$HOME/.claude"
 HOOKS_DIR="$CLAUDE_DIR/hooks"
 SETTINGS_FILE="$CLAUDE_DIR/settings.json"
 REPO_RAW="https://raw.githubusercontent.com/ashmitb95/claude-notifier/main"
+REPO_API="https://api.github.com/repos/ashmitb95/claude-notifier/contents"
 
 echo "Installing Claude Notifier..."
 
@@ -25,8 +26,16 @@ for script in claude-notifier-on-stop.js claude-notifier-on-permission.js claude
   chmod +x "$HOOKS_DIR/$script"
 done
 
-# Shared hook library (required by the hook scripts since v3.0)
-for lib in platform.js paths.js sounds.js config.js play.js notify.js signal.js active.js; do
+# Shared hook library (required by the hook scripts since v3.0).
+# Derive the file list from the repo so it can't drift as new _lib modules are added.
+for lib in $(curl -fsSL "$REPO_API/hook/_lib?ref=main" | node -e "
+let s = '';
+process.stdin.on('data', d => (s += d)).on('end', () => {
+  JSON.parse(s)
+    .filter(e => e.type === 'file' && e.name.endsWith('.js'))
+    .forEach(e => console.log(e.name));
+});
+"); do
   curl -fsSL "$REPO_RAW/hook/_lib/$lib" -o "$HOOKS_DIR/_lib/$lib"
 done
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-notifier",
-  "version": "3.2.0",
+  "version": "3.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-notifier",
-      "version": "3.2.0",
+      "version": "3.3.1",
       "devDependencies": {
         "@eslint/js": "^10.0.1",
         "@types/node": "^20.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "claude-notifier",
   "displayName": "Claude Notifier",
   "description": "Plays distinct sounds when Claude Code finishes a task or needs your input",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "icon": "media/icon.png",
   "publisher": "SingularityInc",
   "repository": {

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -22,7 +22,7 @@ if [ -f "$SETTINGS_FILE" ]; then
   node -e "
 const fs = require('fs');
 const settings = JSON.parse(fs.readFileSync('$SETTINGS_FILE', 'utf-8'));
-for (const t of ['Stop', 'PermissionRequest', 'PreToolUse', 'Notification']) {
+for (const t of ['Stop', 'PermissionRequest', 'PreToolUse', 'Notification', 'UserPromptSubmit']) {
   if (settings.hooks?.[t]) {
     settings.hooks[t] = settings.hooks[t].filter(
       e => !e.hooks?.some(h => h.command?.includes('claude-notifier'))


### PR DESCRIPTION
Fixes #50.

## Why

Two real bugs in the install/uninstall scripts (reported in #50):

1. **install.sh hardcoded the `_lib` copy list**, which silently rotted as new modules were added. `pid.js`, `click.js`, `task-timer.js`, and `cmux.js` are all required by the hooks but were absent from the list, so a fresh `curl | bash` install crashed every hook (e.g. `Cannot find module './cmux'`).
2. **uninstall.sh never removed the `UserPromptSubmit` hook** that install.sh registers, leaving a dangling registration behind.

## Changes

- **install.sh** — instead of re-listing the four currently-missing modules (which would just rot again), derive the `_lib` file list from the repo via the GitHub contents API. New modules are picked up automatically; this class of bug can't recur.
- **uninstall.sh** — add `UserPromptSubmit` to the hook cleanup list.

## Verification

- `bash -n` passes on both scripts.
- The API-derived list resolves to all 12 `_lib` modules, including the four that were missing.