### PR TITLE
fix: add missing _lib modules to install.sh and clean UserPromptSubmit in uninstall.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -26,7 +26,7 @@ for script in claude-notifier-on-stop.js claude-notifier-on-permission.js claude
 done
 
 # Shared hook library (required by the hook scripts since v3.0)
-for lib in platform.js paths.js sounds.js config.js play.js notify.js signal.js active.js; do
+for lib in platform.js paths.js sounds.js config.js play.js notify.js signal.js active.js pid.js click.js task-timer.js cmux.js; do
   curl -fsSL "$REPO_RAW/hook/_lib/$lib" -o "$HOOKS_DIR/_lib/$lib"
 done
 

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -22,7 +22,7 @@ if [ -f "$SETTINGS_FILE" ]; then
   node -e "
 const fs = require('fs');
 const settings = JSON.parse(fs.readFileSync('$SETTINGS_FILE', 'utf-8'));
-for (const t of ['Stop', 'PermissionRequest', 'PreToolUse', 'Notification']) {
+for (const t of ['Stop', 'PermissionRequest', 'PreToolUse', 'Notification', 'UserPromptSubmit']) {
   if (settings.hooks?.[t]) {
     settings.hooks[t] = settings.hooks[t].filter(
       e => !e.hooks?.some(h => h.command?.includes('claude-notifier'))


### PR DESCRIPTION
## Summary

`install.sh` was missing 4 required `_lib` modules (`pid.js`, `click.js`, `task-timer.js`, `cmux.js`), causing every hook to crash immediately after a fresh install.

`uninstall.sh` was not cleaning up `UserPromptSubmit` hook entries, leaving orphaned hook registrations behind in `settings.json`.

## Changes

- **install.sh**: Added `pid.js`, `click.js`, `task-timer.js`, and `cmux.js` to the `_lib` copy list
- **uninstall.sh**: Added `UserPromptSubmit` to the hook types cleaned during uninstall

## Fixes

Fixes #50