### PR TITLE
fix(linux): play .oga sounds via pw-play/paplay before aplay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [3.3.2] - 2026-06-05
+
+### Fixed
+
+- **Static instead of sound on Linux without PulseAudio.** The Linux audio path tried `paplay` and fell back to `aplay`. The preset sounds are Ogg (`.oga`) files, which `aplay` (a raw ALSA/WAV player) cannot decode — it renders them as static. On modern PipeWire-based distros (e.g. Ubuntu 24.04+) `paplay` isn't installed by default, so playback fell through to `aplay` and produced static in every scenario. The player chain now tries `pw-play` (PipeWire) first, then `paplay` (PulseAudio), then `aplay`, so audio works out of the box on PipeWire systems. This bug had been latent since Linux support was added in 2.4.0 and was exposed by distros moving to PipeWire. ([#49](https://github.com/ashmitb95/claude-notifier/issues/49))
+
 ## [3.3.1] - 2026-06-05
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Five [Claude Code hooks](https://docs.anthropic.com/en/docs/claude-code/hooks) a
 
 Each hook reads `~/.claude/hooks/claude-notifier-config.json` (synced from VSCode settings) to determine which sound to play and whether to show notifications.
 
-On **macOS**, hooks use `afplay` and `osascript`. On **Windows** and **WSL**, hooks use PowerShell with `NotifyIcon` balloon tips and system sounds. On **Linux**, hooks use `paplay` (with `aplay` as fallback) for audio and `notify-send` for notifications — install `libnotify` (`notify-send`), a PulseAudio/PipeWire or ALSA stack, and the `sound-theme-freedesktop` package if they aren't already present.
+On **macOS**, hooks use `afplay` and `osascript`. On **Windows** and **WSL**, hooks use PowerShell with `NotifyIcon` balloon tips and system sounds. On **Linux**, hooks use `pw-play` (PipeWire) or `paplay` (PulseAudio) for audio, falling back to `aplay`, and `notify-send` for notifications — install `libnotify` (`notify-send`), a PipeWire (`pipewire-bin` / `pipewire-audio`) or PulseAudio (`pulseaudio-utils`) stack, and the `sound-theme-freedesktop` package if they aren't already present. The sounds are Ogg (`.oga`) files; `aplay` cannot decode them (it plays static), so a PipeWire or PulseAudio player is recommended.
 
 ### Behavior
 
@@ -196,7 +196,7 @@ Remove-Item "$env:USERPROFILE\.claude\hooks\claude-notifier-muted" # unmute
 | macOS    | Yes              | Yes         | Node.js                                                   |
 | Windows  | Yes              | VSCode only | PowerShell                                                |
 | WSL      | Yes              | Yes         | Node.js (calls `powershell.exe` for sounds/notifications) |
-| Linux    | Yes              | Yes         | Node.js (uses `paplay`/`aplay` and `notify-send`)         |
+| Linux    | Yes              | Yes         | Node.js (uses `pw-play`/`paplay`/`aplay` and `notify-send`) |
 
 ## Contributing
 

--- a/hook/_lib/play.js
+++ b/hook/_lib/play.js
@@ -38,10 +38,13 @@ function playSound(primaryPath, fallbackPath, volume = 1) {
         { stdio: "ignore", timeout: 5000 }
       );
     } else if (IS_LINUX) {
-      // paplay --volume uses a 16-bit scale where 65536 = 100%.
+      // pw-play (PipeWire) / paplay (PulseAudio) decode .oga sounds; aplay is a
+      // raw ALSA/WAV player and renders .oga as static (#49), so it is a last
+      // resort. pw-play --volume is a 0.0–1.0+ linear factor; paplay --volume a
+      // 16-bit scale where 65536 = 100%.
       const paVolume = Math.round(v * 65536);
       execSync(
-        `paplay --volume=${paVolume} "${soundPath}" 2>/dev/null || aplay "${soundPath}" 2>/dev/null`,
+        `pw-play --volume=${v} "${soundPath}" 2>/dev/null || paplay --volume=${paVolume} "${soundPath}" 2>/dev/null || aplay "${soundPath}" 2>/dev/null`,
         { stdio: "ignore", timeout: 5000 }
       );
     } else {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-notifier",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-notifier",
-      "version": "3.3.1",
+      "version": "3.3.2",
       "devDependencies": {
         "@eslint/js": "^10.0.1",
         "@types/node": "^20.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "claude-notifier",
   "displayName": "Claude Notifier",
   "description": "Plays distinct sounds when Claude Code finishes a task or needs your input",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "icon": "media/icon.png",
   "publisher": "SingularityInc",
   "repository": {

--- a/src/notifications/sound.ts
+++ b/src/notifications/sound.ts
@@ -64,12 +64,15 @@ export function playLocalSound(
       { timeout: 5000 }
     );
   } else if (IS_LINUX) {
-    // paplay --volume uses a 16-bit scale where 65536 = 100%. aplay has no
-    // matching flag, so the fallback path plays at system volume.
+    // The sounds are Ogg (.oga). Decode them with pw-play (PipeWire, default on
+    // modern distros) or paplay (PulseAudio); aplay is a last resort only — it
+    // is a raw ALSA/WAV player and renders .oga as static (#49). Volume flags
+    // differ: pw-play takes a 0.0–1.0+ linear factor, paplay a 16-bit scale
+    // where 65536 = 100%; aplay has none, so it plays at system volume.
     const soundPath = LINUX_SOUNDS[soundName] || `${LINUX_SOUNDS_DIR}/complete.oga`;
     const paVolume = Math.round(v * 65536);
     exec(
-      `paplay --volume=${paVolume} "${soundPath}" 2>/dev/null || aplay "${soundPath}" 2>/dev/null`,
+      `pw-play --volume=${v} "${soundPath}" 2>/dev/null || paplay --volume=${paVolume} "${soundPath}" 2>/dev/null || aplay "${soundPath}" 2>/dev/null`,
       { timeout: 5000 }
     );
   } else {


### PR DESCRIPTION
Fixes #49.

## Symptom

On Linux, notifications played **static** in every scenario out of the box. The reporter (Ubuntu 26.04) worked around it with `sudo apt install pulseaudio-utils`.

## Root cause

The Linux player chain was `paplay … || aplay …`. The preset sounds are Ogg (`.oga`) files from the freedesktop theme. `aplay` is a raw ALSA/WAV player — it **cannot decode Ogg**, so it plays the compressed bytes as PCM → static.

On modern **PipeWire**-based distros (Ubuntu 24.04+/26.04), `paplay` isn't installed by default (it ships in `pulseaudio-utils`), so the chain fell through to `aplay` → static. Installing `pulseaudio-utils` restores the `paplay` binary, which is why the workaround worked.

This is **not** a regression from the v3.0 refactor — the `paplay || aplay` + `.oga` combination has been present since Linux support landed in **2.4.0** (#13). It was latent because `paplay` was reliably present on PulseAudio systems; the shift to PipeWire-by-default exposed it.

## Fix

Try `pw-play` (PipeWire, present by default on affected systems) first, then `paplay` (PulseAudio), then `aplay` as a last resort:

```
pw-play --volume=<v> "$f" || paplay --volume=<paVolume> "$f" || aplay "$f"
```

Mirrored in both playback sites:
- `src/notifications/sound.ts` (extension `playLocalSound`)
- `hook/_lib/play.js` (CLI hooks)

README runtime-deps and platform-support note updated to mention `pw-play` and that `aplay` can't decode `.oga`.

## Verification

- `npm run typecheck`, `npm run lint`, `npm run format:check` all clean
- Full test suite passes (no test asserted the Linux command string; hook tests strip `PATH` so no player runs)
- `pw-play --volume` takes a 0.0–1.0+ linear factor (same semantics as the existing clamped `v`); `paplay --volume` keeps its 16-bit `65536 = 100%` scale

Patch release → 3.3.2.