### PR TITLE
chore: add Ko-fi sponsor link + bump to 3.5.1

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+ko_fi: ashmitb95

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Claude Notifier
 
 [![VS Marketplace](https://img.shields.io/visual-studio-marketplace/v/SingularityInc.claude-notifier)](https://marketplace.visualstudio.com/items?itemName=SingularityInc.claude-notifier)
+[![Ko-fi](https://img.shields.io/badge/Ko--fi-support-ff5e5b?logo=ko-fi&logoColor=white)](https://ko-fi.com/ashmitb95)
 
 Plays a sound and shows a notification when [Claude Code](https://claude.com/claude-code) finishes a task, needs permission, or asks a question.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-notifier",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-notifier",
-      "version": "3.5.0",
+      "version": "3.5.1",
       "devDependencies": {
         "@eslint/js": "^10.0.1",
         "@types/node": "^20.0.0",

--- a/package.json
+++ b/package.json
@@ -2,12 +2,15 @@
   "name": "claude-notifier",
   "displayName": "Claude Notifier",
   "description": "Plays distinct sounds when Claude Code finishes a task or needs your input",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "icon": "media/icon.png",
   "publisher": "SingularityInc",
   "repository": {
     "type": "git",
     "url": "https://github.com/ashmitb95/claude-notifier"
+  },
+  "sponsor": {
+    "url": "https://ko-fi.com/ashmitb95"
   },
   "engines": {
     "vscode": "^1.85.0"


### PR DESCRIPTION
Small follow-up off latest `main` (after the README streamline in #66).

- **`package.json` `sponsor` field** → Sponsor button on the Marketplace listing + Extensions sidebar (surfaces once 3.5.1 is published).
- **`.github/FUNDING.yml`** → Sponsor button on the GitHub repo (live once on `main`).
- **Ko-fi badge** in the README header.
- **Version bump 3.5.0 → 3.5.1** (no functional change, so no CHANGELOG entry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)