### PR TITLE
fix: use local time instead of UTC in log timestamps

### DIFF
--- a/src/log.ts
+++ b/src/log.ts
@@ -16,7 +16,13 @@ export function initLogger(context: vscode.ExtensionContext): void {
 
 export function log(...parts: unknown[]): void {
   if (!channel) return;
-  const ts = new Date().toISOString().slice(11, 23); // HH:MM:SS.mmm
+  // Use local time instead of UTC
+  const now = new Date();
+  const ts = [
+    String(now.getHours()).padStart(2, "0"),
+    String(now.getMinutes()).padStart(2, "0"),
+    String(now.getSeconds()).padStart(2, "0"),
+  ].join(":") + "." + String(now.getMilliseconds()).padStart(3, "0");
   const msg = parts.map((p) => (typeof p === "string" ? p : JSON.stringify(p))).join(" ");
   channel.appendLine(`[${ts}] ${msg}`);
 }


### PR DESCRIPTION
The extension was using Date.toISOString() which returns UTC time. This caused log timestamps to be 8 hours behind local time for users in UTC+8 timezone (China, Singapore, etc).

Changed to use local time methods (getHours/getMinutes/getSeconds) to display timestamps in the user's local timezone.

## Summary

<one paragraph or 2–3 bullets: what changed and why>

## Test plan

- [ ] `npm test` green locally
- [ ] `npm run typecheck && npm run lint && npm run format:check` green
- [ ] `npm run smoke` green (macOS)
- [ ] Sideloaded the produced `.vsix` into a fresh VS Code profile and confirmed expected behavior
- [ ] If touching hooks or dispatch: ran the `/test-notifier` skill end-to-end

## Notes for reviewer

<design choices, deferred work, platform caveats — anything not obvious from the diff>
