### PR TITLE
fix(windows): normalize paths for case-insensitive comparison on Windows

### DIFF
--- a/hook/_lib.ps1
+++ b/hook/_lib.ps1
@@ -106,8 +106,12 @@ function Write-NotifierSignal([string]$Reason, [string]$SessionId, [string]$Cwd)
 }
 
 # True when $Cwd is inside $Folder (handles trailing separator equivalence).
+# On Windows, paths are case-insensitive — normalize to lowercase for parity
+# with cwdMatchesFolder() in src/routing/cwd.ts.
 function Test-CwdInsideFolder([string]$Cwd, [string]$Folder) {
     if (-not $Cwd -or -not $Folder) { return $false }
+    $isWindows = [IO.Path]::DirectorySeparatorChar -eq '\'
+    if ($isWindows) { $Cwd = $Cwd.ToLower(); $Folder = $Folder.ToLower() }
     if ($Cwd -eq $Folder) { return $true }
     $sep = [IO.Path]::DirectorySeparatorChar
     if (-not $Folder.EndsWith($sep)) { $Folder = $Folder + $sep }

--- a/hook/_lib/active.js
+++ b/hook/_lib/active.js
@@ -4,9 +4,15 @@ const { ACTIVE_DIR } = require("./paths");
 
 function cwdInsideFolder(cwd, folder) {
   if (!cwd || !folder) return false;
-  if (cwd === folder) return true;
+  // On Windows, paths are case-insensitive — normalize for parity with
+  // cwdMatchesFolder() in src/routing/cwd.ts.
+  const isWindows = process.platform === "win32";
+  const normalize = (p) => (isWindows ? p.toLowerCase() : p);
+  const normCwd = normalize(cwd);
+  const normFolder = normalize(folder);
+  if (normCwd === normFolder) return true;
   const sep = path.sep;
-  return cwd.startsWith(folder.endsWith(sep) ? folder : folder + sep);
+  return normCwd.startsWith(normFolder.endsWith(sep) ? normFolder : normFolder + sep);
 }
 
 /**

--- a/src/routing/cwd.ts
+++ b/src/routing/cwd.ts
@@ -25,8 +25,15 @@ export function writeOwnPidFile(): void {
 
 export function cwdMatchesFolder(cwd: string, folder: string): boolean {
   if (!cwd || !folder) return false;
-  if (cwd === folder) return true;
-  return cwd.startsWith(folder.endsWith(path.sep) ? folder : folder + path.sep);
+  // On Windows, paths are case-insensitive — normalize to lowercase for
+  // parity with Test-CwdInsideFolder in hook/_lib.ps1 and cwdInsideFolder
+  // in hook/_lib/active.js.
+  const isWindows = process.platform === "win32";
+  const normalize = (p: string) => (isWindows ? p.toLowerCase() : p);
+  const normCwd = normalize(cwd);
+  const normFolder = normalize(folder);
+  if (normCwd === normFolder) return true;
+  return normCwd.startsWith(normFolder.endsWith(path.sep) ? normFolder : normFolder + path.sep);
 }
 
 export function cleanStalePidFiles(): void {


### PR DESCRIPTION
Windows paths are case-insensitive, but string comparison was case-sensitive. This caused signal routing to fail when workspace folder paths had different case (e.g., 'F:\Github' vs 'f:\Github').

Normalize paths to lowercase on Windows before comparison in:
- cwdMatchesFolder() in src/routing/cwd.ts
- Test-CwdInsideFolder in hook/_lib.ps1
- cwdInsideFolder() in hook/_lib/active.js

This ensures parity across all three path-matching functions.

## Summary

  - Fixed case-sensitive path comparison that broke signal routing on Windows
    when workspace folder paths had different casing (e.g., 'F:\Github' vs 'f:\Github')
  - Normalized paths to lowercase on Windows in all three path-matching functions:
    cwdMatchesFolder() (TS), Test-CwdInsideFolder (PS1), and cwdInsideFolder() (JS)

## Test plan

- [x] `npm test` green locally
- [x] `npm run typecheck && npm run lint && npm run format:check` green
- [ ] `npm run smoke` green (macOS)
- [ ] Sideloaded the produced `.vsix` into a fresh VS Code profile and confirmed expected behavior
- [ ] If touching hooks or dispatch: ran the `/test-notifier` skill end-to-end
- [x] Packaged `.vsix` and verified notifications on Windows

## Notes for reviewer

  PowerShell version uses `[IO.Path]::DirectorySeparatorChar -eq '\'` to detect
  Windows for cross-version compatibility (works in both Windows PowerShell 5.x
  and PowerShell Core 6+).
