### PR TITLE
Remove details

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,1 @@
-ko_fi: ashmitb95
+# ko_fi: ashmitb95

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Claude Notifier
 
 [![VS Marketplace](https://img.shields.io/visual-studio-marketplace/v/SingularityInc.claude-notifier)](https://marketplace.visualstudio.com/items?itemName=SingularityInc.claude-notifier)
-[![Ko-fi](https://img.shields.io/badge/Ko--fi-support-ff5e5b?logo=ko-fi&logoColor=white)](https://ko-fi.com/ashmitb95)
 
 Plays a sound and shows a notification when [Claude Code](https://claude.com/claude-code) finishes a task, needs permission, or asks a question.
 

--- a/package.json
+++ b/package.json
@@ -9,9 +9,6 @@
     "type": "git",
     "url": "https://github.com/ashmitb95/claude-notifier"
   },
-  "sponsor": {
-    "url": "https://ko-fi.com/ashmitb95"
-  },
   "engines": {
     "vscode": "^1.85.0"
   },


### PR DESCRIPTION
## Summary

Removes the sponsor/funding links so no "Sponsor" affordance appears on either the VS Code Marketplace listing or the GitHub repository page.

- Deleted the `sponsor` field from `package.json` (this is what renders the Sponsor button on the marketplace).
- Removed the Ko-fi badge from the `README.md` header (the README is displayed on the marketplace page).
- Commented out the `ko_fi` entry in `.github/FUNDING.yml` so the Sponsor button no longer shows on the repo page (left commented rather than deleted so it's easy to restore later).

## Test plan

- [ ] `npm test` green locally
- [ ] `npm run typecheck && npm run lint && npm run format:check` green
- [ ] `npm run smoke` green (macOS)
- [ ] Sideloaded the produced `.vsix` into a fresh VS Code profile and confirmed expected behavior
- [ ] If touching hooks or dispatch: ran the `/test-notifier` skill end-to-end

Note: this change is metadata/docs only — no runtime, hook, or dispatch code is touched, so the behavioral items above are not expected to be affected.

## Notes for reviewer

`.github/FUNDING.yml` was commented out rather than deleted (per preference) so it can be restored trivially. The `package.json` sponsor field could not be commented (JSON has no comment syntax) and was removed outright.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MbhXnMFNRtDVZpbRaAQhqS)_