### PR TITLE
feat: title notifications with the workspace name

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ A dedicated `SubagentStop` hook fires when a `Task` subagent finishes. The level
 ## How it works
 
 - **Per-session dedup.** Rapid back-to-back events within a single Claude session coalesce automatically — one notification per stage, not a flood. A stage advances when you send your next prompt or after ~30 minutes of idle time.
+- **Project-labelled notifications.** The notification title is the workspace name (or the project directory's name when the hook fires outside VS Code), so with several projects open you can tell which one just finished without opening anything.
 - **Bundled fallback sounds.** If the configured system sound file is missing on disk, a bundled WAV plays so you still hear something.
 - **Defers to other notification hosts.** Inside VS Code, the extension takes over from the hook fallback for the owning window. Inside [cmux](https://github.com/manaflow-ai/cmux), the hook detects cmux's `CMUX_CLAUDE_HOOK_CMUX_BIN` env var and skips its own sound + popup so cmux's native banner doesn't get double-stacked. Inside [Cursor](https://cursor.com) — which runs `~/.claude/settings.json` hooks from its own Composer agent — the hook detects Cursor's `CURSOR_*` environment and stays silent, so you don't get a notification for work that isn't a Claude Code session.
 - **Diagnostic log.** `View → Output → Claude Notifier` shows activation, signal receipts, dedup decisions, and configuration warnings — useful when debugging "I didn't get a notification."

--- a/hook/_lib.ps1
+++ b/hook/_lib.ps1
@@ -79,14 +79,27 @@ function Invoke-NotifierSound([string]$Path, [string]$Fallback) {
     } catch {}
 }
 
-# Show a Windows balloon notification (title is always "Claude Notifier").
-function Show-NotifierNotification([string]$Message) {
+# Notification title for a hook firing in $Cwd — the project directory's leaf
+# name, so parallel Claude sessions are distinguishable at a glance in the
+# tray. Mirrors titleForCwd in hook/_lib/title.js. Falls back to
+# "Claude Notifier" when there's no usable leaf.
+function Get-NotifierTitle([string]$Cwd) {
+    if (-not $Cwd) { return 'Claude Notifier' }
+    $leaf = @($Cwd -split '[\\/]+' | Where-Object { $_ }) | Select-Object -Last 1
+    if ($leaf) { return $leaf }
+    return 'Claude Notifier'
+}
+
+# Show a Windows balloon notification. Pass -Title (see Get-NotifierTitle) to
+# label it with the project; defaults to "Claude Notifier".
+function Show-NotifierNotification([string]$Message, [string]$Title = 'Claude Notifier') {
     try {
+        if (-not $Title) { $Title = 'Claude Notifier' }
         Add-Type -AssemblyName System.Windows.Forms
         $n = New-Object System.Windows.Forms.NotifyIcon
         $n.Icon = [System.Drawing.SystemIcons]::Information
         $n.Visible = $true
-        $n.ShowBalloonTip(3000, 'Claude Notifier', $Message, [System.Windows.Forms.ToolTipIcon]::None)
+        $n.ShowBalloonTip(3000, $Title, $Message, [System.Windows.Forms.ToolTipIcon]::None)
         Start-Sleep -Milliseconds 500
         $n.Dispose()
     } catch {}

--- a/hook/_lib/notify.js
+++ b/hook/_lib/notify.js
@@ -31,7 +31,11 @@ function findTerminalNotifier() {
 }
 
 /**
- * Show an OS notification. Title is always "Claude Notifier".
+ * Show an OS notification.
+ *
+ * opts.title: notification title — pass the workspace name (see
+ * _lib/title.js) so notifications from parallel projects are distinguishable.
+ * Defaults to "Claude Notifier" when omitted.
  *
  * On macOS: when opts.preferTerminalNotifier is true and terminal-notifier is
  * installed, use it (gives clickable notifications that focus VS Code). Else
@@ -53,10 +57,11 @@ function showNotification(message, opts = {}) {
   if (isInsideCmux()) return;
   const preferTn = !!opts.preferTerminalNotifier;
   const executeCmd = opts.executeCmd;
+  const title = opts.title ? String(opts.title) : TITLE;
   try {
     if (USE_WIN) {
       const safeMsg = psSingleQuoteEscape(message);
-      const safeTitle = psSingleQuoteEscape(TITLE);
+      const safeTitle = psSingleQuoteEscape(title);
       const ps = `Add-Type -AssemblyName System.Windows.Forms; $n=New-Object System.Windows.Forms.NotifyIcon; $n.Icon=[System.Drawing.SystemIcons]::Information; $n.Visible=$true; $n.ShowBalloonTip(3000,'${safeTitle}','${safeMsg}',[System.Windows.Forms.ToolTipIcon]::None); Start-Sleep -m 500; $n.Dispose()`;
       execSync(
         `${PS_BIN} -NoProfile -NonInteractive -EncodedCommand ${Buffer.from(ps, "utf16le").toString("base64")}`,
@@ -64,7 +69,7 @@ function showNotification(message, opts = {}) {
       );
     } else if (IS_LINUX) {
       // execFileSync bypasses the shell — no shell-escaping concerns for $ or `.
-      execFileSync("notify-send", ["--app-name=Claude Code", TITLE, String(message)], {
+      execFileSync("notify-send", ["--app-name=Claude Code", title, String(message)], {
         stdio: "ignore",
         timeout: 5000,
       });
@@ -72,7 +77,7 @@ function showNotification(message, opts = {}) {
       if (preferTn) {
         const tn = findTerminalNotifier();
         if (tn) {
-          const args = ["-title", TITLE, "-message", String(message)];
+          const args = ["-title", title, "-message", String(message)];
           if (executeCmd) args.push("-execute", executeCmd);
           execFileSync(tn, args, { stdio: "ignore" });
           return;
@@ -80,9 +85,12 @@ function showNotification(message, opts = {}) {
       }
       // execFileSync bypasses the shell; AppleScript still needs its own \ and " escaping.
       const escaped = appleScriptEscape(message);
-      execFileSync("osascript", ["-e", `display notification "${escaped}" with title "${TITLE}"`], {
-        stdio: "ignore",
-      });
+      const escapedTitle = appleScriptEscape(title);
+      execFileSync(
+        "osascript",
+        ["-e", `display notification "${escaped}" with title "${escapedTitle}"`],
+        { stdio: "ignore" }
+      );
     }
   } catch {}
 }

--- a/hook/_lib/title.js
+++ b/hook/_lib/title.js
@@ -1,0 +1,21 @@
+const DEFAULT_TITLE = "Claude Notifier";
+
+/**
+ * Notification title for a hook firing in `cwd` — the project directory's
+ * leaf name, so parallel Claude sessions are distinguishable at a glance in
+ * Notification Center / the Windows tray.
+ *
+ * Splits on both separators rather than using path.basename: a hook payload
+ * carries the cwd style of the machine Claude runs on, which isn't always the
+ * style of the machine formatting the notification (WSL, remote shells).
+ * Falls back to "Claude Notifier" when there's no usable leaf (empty cwd, "/").
+ */
+function titleForCwd(cwd) {
+  if (!cwd) return DEFAULT_TITLE;
+  const parts = String(cwd)
+    .split(/[\\/]+/)
+    .filter(Boolean);
+  return parts[parts.length - 1] || DEFAULT_TITLE;
+}
+
+module.exports = { titleForCwd, DEFAULT_TITLE };

--- a/hook/claude-notifier-on-notification.js
+++ b/hook/claude-notifier-on-notification.js
@@ -7,6 +7,7 @@ const { isMuted, isDisabled, readConfig } = require("./_lib/config");
 const { BUNDLED_FALLBACK } = require("./_lib/sounds");
 const { emitSound } = require("./_lib/emit");
 const { showNotification } = require("./_lib/notify");
+const { titleForCwd } = require("./_lib/title");
 const { writeSignal } = require("./_lib/signal");
 
 let raw = "";
@@ -42,7 +43,8 @@ process.stdin.on("end", () => {
   );
 
   const message = input.message || "Claude needs your permission.";
-  showNotification(message);
+  const cwd = (input && input.cwd) || process.cwd() || "";
+  showNotification(message, { title: titleForCwd(cwd) });
 
   writeSignal("input", input.session_id);
 

--- a/hook/claude-notifier-on-notification.ps1
+++ b/hook/claude-notifier-on-notification.ps1
@@ -14,7 +14,7 @@ if (Test-NotifierMuted) { exit 0 }
 Invoke-NotifierSound -Path 'C:\Windows\Media\Windows Notify.wav' -Fallback $LibBundledFallback.needsPermission
 
 $message = if ($data.message) { $data.message } else { 'Claude needs your permission.' }
-Show-NotifierNotification -Message $message
+Show-NotifierNotification -Message $message -Title (Get-NotifierTitle $data.cwd)
 
 Write-NotifierSignal -Reason 'input' -SessionId $data.session_id
 

--- a/hook/claude-notifier-on-permission.js
+++ b/hook/claude-notifier-on-permission.js
@@ -5,6 +5,7 @@ const { isMuted, isDisabled, readConfig } = require("./_lib/config");
 const { BUNDLED_FALLBACK } = require("./_lib/sounds");
 const { emitSound } = require("./_lib/emit");
 const { showNotification } = require("./_lib/notify");
+const { titleForCwd } = require("./_lib/title");
 const { writeSignal } = require("./_lib/signal");
 const { buildClickAction, GENERIC_ACTIVATE } = require("./_lib/click");
 const { shouldSuppressForThreshold } = require("./_lib/task-timer");
@@ -68,6 +69,7 @@ process.stdin.on("end", () => {
     const tool = input.tool_name || "a tool";
     const cwd = (input && input.cwd) || process.cwd() || "";
     showNotification(`Claude needs permission to use ${tool}.`, {
+      title: titleForCwd(cwd),
       preferTerminalNotifier: true,
       executeCmd: buildClickAction(cwd) || GENERIC_ACTIVATE,
     });

--- a/hook/claude-notifier-on-permission.ps1
+++ b/hook/claude-notifier-on-permission.ps1
@@ -36,7 +36,7 @@ if ($level -eq 'sound+popup' -or $level -eq 'sound') {
 
 if ($level -eq 'sound+popup' -or $level -eq 'popup') {
     $tool = if ($data.tool_name) { $data.tool_name } else { 'a tool' }
-    Show-NotifierNotification -Message "Claude needs permission to use $tool."
+    Show-NotifierNotification -Message "Claude needs permission to use $tool." -Title (Get-NotifierTitle $data.cwd)
 }
 
 Write-NotifierSignal -Reason 'input' -SessionId $data.session_id

--- a/hook/claude-notifier-on-question.js
+++ b/hook/claude-notifier-on-question.js
@@ -5,6 +5,7 @@ const { isMuted, isDisabled, readConfig } = require("./_lib/config");
 const { BUNDLED_FALLBACK } = require("./_lib/sounds");
 const { emitSound } = require("./_lib/emit");
 const { showNotification } = require("./_lib/notify");
+const { titleForCwd } = require("./_lib/title");
 const { writeSignal } = require("./_lib/signal");
 const { buildClickAction, GENERIC_ACTIVATE } = require("./_lib/click");
 const { shouldSuppressForThreshold } = require("./_lib/task-timer");
@@ -63,6 +64,7 @@ process.stdin.on("end", () => {
   if (level === "sound+popup" || level === "popup") {
     const cwd = (input && input.cwd) || process.cwd() || "";
     showNotification("Claude is asking you a question.", {
+      title: titleForCwd(cwd),
       preferTerminalNotifier: true,
       executeCmd: buildClickAction(cwd) || GENERIC_ACTIVATE,
     });

--- a/hook/claude-notifier-on-question.ps1
+++ b/hook/claude-notifier-on-question.ps1
@@ -35,7 +35,7 @@ if ($level -eq 'sound+popup' -or $level -eq 'sound') {
 }
 
 if ($level -eq 'sound+popup' -or $level -eq 'popup') {
-    Show-NotifierNotification -Message 'Claude is asking you a question.'
+    Show-NotifierNotification -Message 'Claude is asking you a question.' -Title (Get-NotifierTitle $data.cwd)
 }
 
 Write-NotifierSignal -Reason 'question' -SessionId $data.session_id

--- a/hook/claude-notifier-on-stop.js
+++ b/hook/claude-notifier-on-stop.js
@@ -7,6 +7,7 @@ const { isMuted, isDisabled, readConfig } = require("./_lib/config");
 const { BUNDLED_FALLBACK } = require("./_lib/sounds");
 const { emitSound } = require("./_lib/emit");
 const { showNotification } = require("./_lib/notify");
+const { titleForCwd } = require("./_lib/title");
 const { extensionOwnsCwd } = require("./_lib/active");
 const { writeSignal } = require("./_lib/signal");
 const { getAncestorPids } = require("./_lib/pid");
@@ -66,6 +67,7 @@ process.stdin.on("end", () => {
     // Stop notifications fire when the user is likely away — prefer
     // terminal-notifier so the click can focus VS Code.
     showNotification("Claude has finished the task.", {
+      title: titleForCwd(cwd),
       preferTerminalNotifier: true,
       executeCmd: buildClickAction(cwd) || GENERIC_ACTIVATE,
     });

--- a/hook/claude-notifier-on-stop.ps1
+++ b/hook/claude-notifier-on-stop.ps1
@@ -36,7 +36,7 @@ if ($level -eq 'sound+popup' -or $level -eq 'sound') {
 }
 
 if ($level -eq 'sound+popup' -or $level -eq 'popup') {
-    Show-NotifierNotification -Message 'Claude has finished the task.'
+    Show-NotifierNotification -Message 'Claude has finished the task.' -Title (Get-NotifierTitle $cwd)
 }
 
 exit 0

--- a/hook/claude-notifier-on-subagent-stop.js
+++ b/hook/claude-notifier-on-subagent-stop.js
@@ -8,6 +8,7 @@ const { isMuted, isDisabled, readConfig } = require("./_lib/config");
 const { BUNDLED_FALLBACK } = require("./_lib/sounds");
 const { emitSound } = require("./_lib/emit");
 const { showNotification } = require("./_lib/notify");
+const { titleForCwd } = require("./_lib/title");
 const { extensionOwnsCwd } = require("./_lib/active");
 const { writeSignal } = require("./_lib/signal");
 const { shouldSuppressForThreshold } = require("./_lib/task-timer");
@@ -62,7 +63,7 @@ process.stdin.on("end", () => {
   }
 
   if (level === "sound+popup" || level === "popup") {
-    showNotification("Claude subagent finished.");
+    showNotification("Claude subagent finished.", { title: titleForCwd(cwd) });
   }
 
   process.exit(0);

--- a/hook/claude-notifier-on-subagent-stop.ps1
+++ b/hook/claude-notifier-on-subagent-stop.ps1
@@ -33,7 +33,7 @@ if ($level -eq 'sound+popup' -or $level -eq 'sound') {
 }
 
 if ($level -eq 'sound+popup' -or $level -eq 'popup') {
-    Show-NotifierNotification -Message 'Claude subagent finished.'
+    Show-NotifierNotification -Message 'Claude subagent finished.' -Title (Get-NotifierTitle $cwd)
 }
 
 exit 0

--- a/src/notifications/local.ts
+++ b/src/notifications/local.ts
@@ -2,15 +2,20 @@ import * as vscode from "vscode";
 import { exec } from "child_process";
 import { IS_WIN, IS_MAC, FOCUS_SIGNAL_FILE } from "../paths";
 import { getTerminalNotifierPath, getCodeCliPath } from "./terminal-notifier";
+import { getWorkspaceTitle } from "./title";
 
 function shellQuote(s: string): string {
   return `'${s.replace(/'/g, `'\\''`)}'`;
 }
 
 export function showLocalNotification(message: string, cwd?: string): void {
+  // Title the notification with the workspace name so notifications from
+  // parallel projects are distinguishable in Notification Center / the tray.
+  const title = getWorkspaceTitle(cwd);
   if (IS_WIN) {
     const safeMsg = message.replace(/'/g, "''");
-    const ps = `Add-Type -AssemblyName System.Windows.Forms; $n=New-Object System.Windows.Forms.NotifyIcon; $n.Icon=[System.Drawing.SystemIcons]::Information; $n.Visible=$true; $n.ShowBalloonTip(3000,'Claude Notifier','${safeMsg}',[System.Windows.Forms.ToolTipIcon]::None); Start-Sleep -m 500; $n.Dispose()`;
+    const safeTitle = title.replace(/'/g, "''");
+    const ps = `Add-Type -AssemblyName System.Windows.Forms; $n=New-Object System.Windows.Forms.NotifyIcon; $n.Icon=[System.Drawing.SystemIcons]::Information; $n.Visible=$true; $n.ShowBalloonTip(3000,'${safeTitle}','${safeMsg}',[System.Windows.Forms.ToolTipIcon]::None); Start-Sleep -m 500; $n.Dispose()`;
     exec(
       `powershell -NoProfile -NonInteractive -EncodedCommand ${Buffer.from(ps, "utf16le").toString("base64")}`,
       { timeout: 5000 }
@@ -31,10 +36,13 @@ export function showLocalNotification(message: string, cwd?: string): void {
         ? `${shellQuote(codeCli)} ${shellQuote(folder)}`
         : `osascript -e 'tell application "Visual Studio Code" to activate'`;
     const executeCmd = focusWrite ? `${focusWrite}; ${bringForward}` : bringForward;
-    const args = ["-title", "Claude Notifier", "-message", message, "-execute", executeCmd];
+    const args = ["-title", title, "-message", message, "-execute", executeCmd];
     exec(`${shellQuote(tn)} ${args.map(shellQuote).join(" ")}`);
   } else {
-    const safeMsg = message.replace(/[\\"]/g, "\\$&");
-    exec(`osascript -e 'display notification "${safeMsg}" with title "Claude Notifier"'`);
+    // AppleScript needs its own \ and " escaping; the whole script is then
+    // shell-quoted, so an apostrophe in the workspace name is safe too.
+    const escape = (s: string) => s.replace(/[\\"]/g, "\\$&");
+    const script = `display notification "${escape(message)}" with title "${escape(title)}"`;
+    exec(`osascript -e ${shellQuote(script)}`);
   }
 }

--- a/src/notifications/title.ts
+++ b/src/notifications/title.ts
@@ -1,0 +1,33 @@
+import * as path from "path";
+import * as vscode from "vscode";
+import { getOwnWorkspaceFolders, cwdMatchesFolder } from "../routing/cwd";
+
+export const DEFAULT_TITLE = "Claude Notifier";
+const WORKSPACE_EXT = ".code-workspace";
+
+/**
+ * Title for OS notifications fired by this window: the name of the workspace,
+ * so a user with several projects open can tell at a glance which one just
+ * finished.
+ *
+ * Resolution order:
+ *   1. saved multi-root workspace  → the .code-workspace basename, ext stripped
+ *   2. the workspace folder owning `cwd` (dispatch has already established that
+ *      this window owns it), else the first folder → its basename
+ *   3. `cwd` itself → its basename (folderless window acting as fallback owner)
+ *   4. "Claude Notifier"
+ */
+export function getWorkspaceTitle(cwd?: string): string {
+  const wsFile = vscode.workspace.workspaceFile;
+  if (wsFile && wsFile.scheme === "file") {
+    const base = path.basename(wsFile.fsPath);
+    const name = base.endsWith(WORKSPACE_EXT) ? base.slice(0, -WORKSPACE_EXT.length) : base;
+    if (name) return name;
+  }
+  const folders = getOwnWorkspaceFolders();
+  const owning = cwd ? folders.find((f) => cwdMatchesFolder(cwd, f)) : undefined;
+  const folder = owning ?? folders[0];
+  if (folder && path.basename(folder)) return path.basename(folder);
+  if (cwd && path.basename(cwd)) return path.basename(cwd);
+  return DEFAULT_TITLE;
+}

--- a/test/_mocks/vscode.ts
+++ b/test/_mocks/vscode.ts
@@ -23,6 +23,7 @@ export const window = {
 
 export const workspace = {
   workspaceFolders: undefined as unknown,
+  workspaceFile: undefined as unknown,
   getConfiguration: (_section?: string) => ({
     get: <T>(_key: string, defaultValue?: T) => defaultValue,
     update: (_key: string, _value: unknown) => Promise.resolve(),

--- a/test/hook/lib.title.test.ts
+++ b/test/hook/lib.title.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+
+const { titleForCwd, DEFAULT_TITLE } = await import("../../hook/_lib/title");
+
+describe("hook/_lib/title — titleForCwd", () => {
+  it("uses the leaf directory name of a POSIX cwd", () => {
+    expect(titleForCwd("/Users/foo/projects/my-app")).toBe("my-app");
+  });
+
+  it("uses the leaf directory name of a Windows cwd", () => {
+    expect(titleForCwd("C:\\Users\\foo\\projects\\my-app")).toBe("my-app");
+  });
+
+  it("ignores a trailing separator", () => {
+    expect(titleForCwd("/Users/foo/my-app/")).toBe("my-app");
+    expect(titleForCwd("C:\\Users\\foo\\my-app\\")).toBe("my-app");
+  });
+
+  it("falls back to the default title when there is no usable leaf", () => {
+    expect(titleForCwd("")).toBe(DEFAULT_TITLE);
+    expect(titleForCwd(undefined)).toBe(DEFAULT_TITLE);
+    expect(titleForCwd(null)).toBe(DEFAULT_TITLE);
+    expect(titleForCwd("/")).toBe(DEFAULT_TITLE);
+  });
+
+  it("keeps names with spaces and punctuation intact", () => {
+    expect(titleForCwd("/Users/foo/it's a project")).toBe("it's a project");
+  });
+});

--- a/test/unit/notifications.title.test.ts
+++ b/test/unit/notifications.title.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import * as vscode from "vscode";
+import { getWorkspaceTitle, DEFAULT_TITLE } from "../../src/notifications/title";
+
+const ws = vscode.workspace as { workspaceFolders: unknown; workspaceFile: unknown };
+
+function setFolders(...paths: string[]): void {
+  ws.workspaceFolders = paths.length ? paths.map((p) => ({ uri: { fsPath: p } })) : undefined;
+}
+
+function setWorkspaceFile(fsPath: string | null, scheme = "file"): void {
+  ws.workspaceFile = fsPath ? { fsPath, scheme } : undefined;
+}
+
+describe("notifications/title — getWorkspaceTitle", () => {
+  beforeEach(() => {
+    setFolders();
+    setWorkspaceFile(null);
+  });
+
+  it("uses the folder name of a single-folder workspace", () => {
+    setFolders("/Users/foo/my-app");
+    expect(getWorkspaceTitle("/Users/foo/my-app")).toBe("my-app");
+  });
+
+  it("uses the folder name even when the cwd is a subdirectory", () => {
+    setFolders("/Users/foo/my-app");
+    expect(getWorkspaceTitle("/Users/foo/my-app/packages/api")).toBe("my-app");
+  });
+
+  it("uses the .code-workspace name for a saved multi-root workspace", () => {
+    setFolders("/Users/foo/api", "/Users/foo/web");
+    setWorkspaceFile("/Users/foo/acme.code-workspace");
+    expect(getWorkspaceTitle("/Users/foo/api")).toBe("acme");
+  });
+
+  it("keeps the basename when the workspace file has no .code-workspace suffix", () => {
+    setWorkspaceFile("/Users/foo/acme.json");
+    expect(getWorkspaceTitle("/Users/foo/api")).toBe("acme.json");
+  });
+
+  it("picks the folder owning the cwd in an untitled multi-root workspace", () => {
+    setFolders("/Users/foo/api", "/Users/foo/web");
+    setWorkspaceFile("/Users/foo/Untitled", "untitled");
+    expect(getWorkspaceTitle("/Users/foo/web/src")).toBe("web");
+  });
+
+  it("falls back to the first folder when the cwd matches none", () => {
+    setFolders("/Users/foo/api", "/Users/foo/web");
+    expect(getWorkspaceTitle("/elsewhere")).toBe("api");
+  });
+
+  it("falls back to the cwd name when the window has no folder open", () => {
+    expect(getWorkspaceTitle("/Users/foo/loose-project")).toBe("loose-project");
+  });
+
+  it("falls back to the default title with neither folder nor cwd", () => {
+    expect(getWorkspaceTitle()).toBe(DEFAULT_TITLE);
+    expect(getWorkspaceTitle("")).toBe(DEFAULT_TITLE);
+  });
+});


### PR DESCRIPTION
## Summary

The OS notification title is hardcoded to "Claude Notifier" on every path. With several projects open, the banners are indistinguishable at a glance — you have to switch windows to find out which one finished. This titles each notification with the project instead.

- **Extension** (`src/notifications/title.ts`, new): saved multi-root workspace → the `.code-workspace` basename with the extension stripped; otherwise the workspace folder owning the signal's `cwd` (`handleSignal`'s routing filter has already established this window owns it), else the first folder; a folderless fallback-owner window uses the `cwd`'s basename; then `"Claude Notifier"`.
- **Hooks** (`hook/_lib/title.js` new, `Get-NotifierTitle` in `hook/_lib.ps1`): the leaf of the firing `cwd`.
- `showNotification` gains an optional `opts.title`; `Show-NotifierNotification` gains `-Title`. Both default to `"Claude Notifier"`, so any caller not updated here keeps the old behavior. All five JS hooks and all five PS1 hooks pass it.

## Test plan

- [x] `npm test` green locally (152 unit + 129 hook, incl. 13 new across `notifications.title` and `lib.title`)
- [x] `npm run typecheck && npm run lint && npm run format:check` green
- [x] `npm run smoke` green (macOS)
- [x] Posted a real notification through `hook/_lib/notify.js` on macOS 26 with `terminal-notifier` — banner titled `claude-notifier` instead of `Claude Notifier`
- [ ] Not sideloaded into a fresh profile; not exercised on Windows or Linux (the PS1 and `notify-send` paths are edited but unverified on those platforms — a sanity check from someone on them would be welcome)

## Notes for reviewer

**Escaping.** The title is now user data (a directory name), so it goes through the escaping the message already had on the interpolating paths: PowerShell single-quote doubling, AppleScript `\` and `"`. `notify.js`'s osascript branch previously interpolated the constant title raw — now escaped. The extension's osascript fallback now shell-quotes the whole AppleScript instead of embedding it in a single-quoted shell string, which also fixes a pre-existing break on any *message* containing an apostrophe. terminal-notifier and `notify-send` args go through `execFileSync`/`shellQuote` already.

**Hook vs extension titles differ for multi-root.** Hooks only ever see a `cwd` — the workspace folder list crosses the process boundary only through the active-marker files, and the config file is global — so a hook-fired notification in a multi-root workspace is labelled with the project directory, not the workspace name. The extension path (which owns the "done" popup whenever a window owns the cwd) gets the workspace name. Threading the real name into the hooks would mean extending the marker format on both the JS and PS1 sides; that seemed like the wrong trade for the case it fixes, but say the word and I'll do it.

**Not made configurable.** No setting to opt out — happy to add `claudeNotifier.notificationTitle: workspace | fixed` if you'd rather not change the default for existing users.

**No test for the `opts.title` plumbing in `notify.js`.** `vi.mock` doesn't intercept the CJS `require`s inside `hook/_lib/*.js`, and the subprocess hook tests deliberately suppress the notify path (`CLAUDE_NOTIFIER_TEST_SUPPRESS_NOTIFY`), so I covered the two pure title resolvers and left the one-line plumbing to review. Happy to add a spawned-binary-on-PATH test if you want it covered.

**Related.** This is one of two leftovers from #15 that #36 didn't cover. The other — multi-root windows opening a *new* window on click because `code <folder>` doesn't match an existing multi-root window — is a separate fix I can send after this if you're interested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
