### PR TITLE
feat: name the session in every notification

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ A dedicated `SubagentStop` hook fires when a `Task` subagent finishes. The level
 
 ## How it works
 
+- **Notifications name the session that fired them.** Popups read `my-repo · Fix the flaky login test · finished` rather than a generic "Claude has finished the task.", so concurrent sessions are tellable apart. The name is the session title Claude Code shows in its own session picker, read from the session transcript, so it maps onto the tab you need to open. When no title can be resolved the previous wording is used unchanged.
 - **Per-session dedup.** Rapid back-to-back events within a single Claude session coalesce automatically — one notification per stage, not a flood. A stage advances when you send your next prompt or after ~30 minutes of idle time.
 - **Bundled fallback sounds.** If the configured system sound file is missing on disk, a bundled WAV plays so you still hear something.
 - **Defers to other notification hosts.** Inside VS Code, the extension takes over from the hook fallback for the owning window. Inside [cmux](https://github.com/manaflow-ai/cmux), the hook detects cmux's `CMUX_CLAUDE_HOOK_CMUX_BIN` env var and skips its own sound + popup so cmux's native banner doesn't get double-stacked. Inside [Cursor](https://cursor.com) — which runs `~/.claude/settings.json` hooks from its own Composer agent — the hook detects Cursor's `CURSOR_*` environment and stays silent, so you don't get a notification for work that isn't a Claude Code session.

--- a/hook/_lib/paths.js
+++ b/hook/_lib/paths.js
@@ -2,6 +2,13 @@ const path = require("path");
 
 const HOOKS_DIR = path.join(process.env.HOME || process.env.USERPROFILE || "~", ".claude", "hooks");
 const MUTE_FLAG = path.join(HOOKS_DIR, "claude-notifier-muted");
+// Claude Code session transcripts, read (never written) to resolve a session
+// title. See _lib/session-label.js.
+const PROJECTS_DIR = path.join(
+  process.env.HOME || process.env.USERPROFILE || "~",
+  ".claude",
+  "projects"
+);
 const SIGNAL_FILE = path.join(HOOKS_DIR, "claude-signal");
 const FOCUS_SIGNAL_FILE = path.join(HOOKS_DIR, "claude-notifier-focus");
 const CONFIG_FILE = path.join(HOOKS_DIR, "claude-notifier-config.json");
@@ -10,6 +17,7 @@ const TASK_START_DIR = path.join(HOOKS_DIR, "claude-notifier-task-start");
 
 module.exports = {
   HOOKS_DIR,
+  PROJECTS_DIR,
   MUTE_FLAG,
   SIGNAL_FILE,
   FOCUS_SIGNAL_FILE,

--- a/hook/_lib/session-label.js
+++ b/hook/_lib/session-label.js
@@ -1,0 +1,170 @@
+const fs = require("fs");
+const path = require("path");
+const { PROJECTS_DIR } = require("./paths");
+
+/**
+ * Resolves a short label identifying WHICH Claude session an event came from,
+ * e.g. "my-repo · Fix the flaky login test".
+ *
+ * Claude Code writes an `ai-title` record into the session transcript at
+ * ~/.claude/projects/<slugged-cwd>/<session-id>.jsonl. That string is what its
+ * own session picker shows, so a label built from it maps directly onto the tab
+ * or session the user needs to open.
+ *
+ * Fails soft everywhere and returns null/"" rather than throwing: the transcript
+ * layout is a Claude Code implementation detail, so callers must be able to fall
+ * back to an unlabelled message.
+ *
+ * Parallel implementation of src/signals/session-label.ts, mirroring the
+ * src/routing/cwd.ts <-> hook/_lib/active.js split. Keep the two in sync.
+ */
+
+const MAX_TITLE = 70;
+// The head-only read keeps this at ~1ms rather than ~110ms on a 28MB
+// transcript. Both signals we look for are written near the start of a session.
+const HEAD_BYTES = 512 * 1024;
+const MAX_FULL_READ_BYTES = 64 * 1024 * 1024;
+
+function exists(p) {
+  try {
+    return fs.existsSync(p);
+  } catch {
+    return false;
+  }
+}
+
+function collapse(value) {
+  const flat = String(value).replace(/\s+/g, " ").trim();
+  return flat.length > MAX_TITLE ? `${flat.slice(0, MAX_TITLE - 1)}…` : flat;
+}
+
+function readHead(filePath, limit) {
+  let fd;
+  try {
+    fd = fs.openSync(filePath, "r");
+    const size = fs.fstatSync(fd).size;
+    const length = Math.min(size, limit);
+    const buf = Buffer.allocUnsafe(length);
+    fs.readSync(fd, buf, 0, length, 0);
+    return { text: buf.toString("utf-8"), truncated: size > length };
+  } catch {
+    return null;
+  } finally {
+    if (fd !== undefined) {
+      try {
+        fs.closeSync(fd);
+      } catch {}
+    }
+  }
+}
+
+function scanForTitle(text) {
+  const lines = text.split("\n");
+
+  // Last ai-title wins: a long session can be re-titled. The substring test
+  // avoids JSON.parse on every line of a large transcript.
+  for (let i = lines.length - 1; i >= 0; i--) {
+    if (!lines[i].includes('"ai-title"')) continue;
+    try {
+      const parsed = JSON.parse(lines[i]);
+      if (parsed && parsed.type === "ai-title" && parsed.aiTitle) return collapse(parsed.aiTitle);
+    } catch {}
+  }
+
+  // Fallback for a session too young to have been titled yet.
+  for (const line of lines) {
+    if (!line.includes('"type":"user"')) continue;
+    try {
+      const parsed = JSON.parse(line);
+      if (!parsed || parsed.type !== "user" || !parsed.message) continue;
+      const content = parsed.message.content;
+      const text2 =
+        typeof content === "string"
+          ? content
+          : Array.isArray(content)
+            ? (content.find((c) => c && c.type === "text") || {}).text || ""
+            : "";
+      // Skip injected <system-reminder> / <ide_selection> style turns.
+      if (text2 && !text2.trimStart().startsWith("<")) return collapse(text2);
+    } catch {}
+  }
+  return null;
+}
+
+/** The session's ai-title, else the first thing the user typed, else null. */
+function readSessionTitle(transcriptPath) {
+  const head = readHead(transcriptPath, HEAD_BYTES);
+  if (!head) return null;
+
+  const fromHead = scanForTitle(head.text);
+  if (fromHead) return fromHead;
+  if (!head.truncated) return null;
+
+  try {
+    if (fs.statSync(transcriptPath).size > MAX_FULL_READ_BYTES) return null;
+    return scanForTitle(fs.readFileSync(transcriptPath, "utf-8"));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Locate a session transcript. The slug guess covers the normal case; the
+ * directory scan is the fallback for any cwd Claude Code slugs differently.
+ */
+function findTranscript(sessionId, cwd, projectsDir = PROJECTS_DIR) {
+  if (!sessionId || sessionId === "-") return null;
+  const fileName = `${sessionId}.jsonl`;
+
+  if (cwd) {
+    const guess = path.join(projectsDir, String(cwd).replace(/\//g, "-"), fileName);
+    if (exists(guess)) return guess;
+  }
+  let entries;
+  try {
+    entries = fs.readdirSync(projectsDir);
+  } catch {
+    return null;
+  }
+  for (const entry of entries) {
+    const candidate = path.join(projectsDir, entry, fileName);
+    if (exists(candidate)) return candidate;
+  }
+  return null;
+}
+
+/**
+ * "<project> · <session title>", or just "<project>" when no title resolves, or
+ * "" when there is nothing to go on. Callers treat "" as "use the plain,
+ * unlabelled message" so behaviour is unchanged when a transcript is missing.
+ */
+function buildSessionLabel(input = {}) {
+  const { cwd, sessionId, transcriptPath, projectsDir = PROJECTS_DIR } = input;
+  const project = cwd ? path.basename(String(cwd).replace(/[\\/]+$/, "")) : "";
+
+  const transcript =
+    transcriptPath && exists(transcriptPath)
+      ? transcriptPath
+      : sessionId
+        ? findTranscript(sessionId, cwd, projectsDir)
+        : null;
+  const title = transcript ? readSessionTitle(transcript) : null;
+
+  if (project && title) return `${project} · ${title}`;
+  return title || project || "";
+}
+
+/**
+ * "<label> · <suffix>" for a hook's stdin payload, falling back to `unlabelled`
+ * when no session label resolves. Keeps each hook script to a single call.
+ */
+function labelledMessage(input, suffix, unlabelled) {
+  const label = buildSessionLabel({
+    cwd: (input && input.cwd) || process.cwd() || "",
+    sessionId: input && input.session_id,
+    transcriptPath: input && input.transcript_path,
+  });
+  return label ? `${label} · ${suffix}` : unlabelled;
+}
+
+module.exports = { buildSessionLabel, labelledMessage, readSessionTitle, findTranscript };

--- a/hook/claude-notifier-on-notification.js
+++ b/hook/claude-notifier-on-notification.js
@@ -7,6 +7,7 @@ const { isMuted, isDisabled, readConfig } = require("./_lib/config");
 const { BUNDLED_FALLBACK } = require("./_lib/sounds");
 const { emitSound } = require("./_lib/emit");
 const { showNotification } = require("./_lib/notify");
+const { labelledMessage } = require("./_lib/session-label");
 const { writeSignal } = require("./_lib/signal");
 
 let raw = "";
@@ -42,7 +43,7 @@ process.stdin.on("end", () => {
   );
 
   const message = input.message || "Claude needs your permission.";
-  showNotification(message);
+  showNotification(labelledMessage(input, message, message));
 
   writeSignal("input", input.session_id);
 

--- a/hook/claude-notifier-on-permission.js
+++ b/hook/claude-notifier-on-permission.js
@@ -5,6 +5,7 @@ const { isMuted, isDisabled, readConfig } = require("./_lib/config");
 const { BUNDLED_FALLBACK } = require("./_lib/sounds");
 const { emitSound } = require("./_lib/emit");
 const { showNotification } = require("./_lib/notify");
+const { labelledMessage } = require("./_lib/session-label");
 const { writeSignal } = require("./_lib/signal");
 const { buildClickAction, GENERIC_ACTIVATE } = require("./_lib/click");
 const { shouldSuppressForThreshold } = require("./_lib/task-timer");
@@ -67,10 +68,17 @@ process.stdin.on("end", () => {
   if (level === "sound+popup" || level === "popup") {
     const tool = input.tool_name || "a tool";
     const cwd = (input && input.cwd) || process.cwd() || "";
-    showNotification(`Claude needs permission to use ${tool}.`, {
-      preferTerminalNotifier: true,
-      executeCmd: buildClickAction(cwd) || GENERIC_ACTIVATE,
-    });
+    showNotification(
+      labelledMessage(
+        input,
+        `needs permission for ${tool}`,
+        `Claude needs permission to use ${tool}.`
+      ),
+      {
+        preferTerminalNotifier: true,
+        executeCmd: buildClickAction(cwd) || GENERIC_ACTIVATE,
+      }
+    );
   }
 
   writeSignal("input", input.session_id);

--- a/hook/claude-notifier-on-question.js
+++ b/hook/claude-notifier-on-question.js
@@ -5,6 +5,7 @@ const { isMuted, isDisabled, readConfig } = require("./_lib/config");
 const { BUNDLED_FALLBACK } = require("./_lib/sounds");
 const { emitSound } = require("./_lib/emit");
 const { showNotification } = require("./_lib/notify");
+const { labelledMessage } = require("./_lib/session-label");
 const { writeSignal } = require("./_lib/signal");
 const { buildClickAction, GENERIC_ACTIVATE } = require("./_lib/click");
 const { shouldSuppressForThreshold } = require("./_lib/task-timer");
@@ -62,10 +63,13 @@ process.stdin.on("end", () => {
 
   if (level === "sound+popup" || level === "popup") {
     const cwd = (input && input.cwd) || process.cwd() || "";
-    showNotification("Claude is asking you a question.", {
-      preferTerminalNotifier: true,
-      executeCmd: buildClickAction(cwd) || GENERIC_ACTIVATE,
-    });
+    showNotification(
+      labelledMessage(input, "asked you a question", "Claude is asking you a question."),
+      {
+        preferTerminalNotifier: true,
+        executeCmd: buildClickAction(cwd) || GENERIC_ACTIVATE,
+      }
+    );
   }
 
   writeSignal("question", input.session_id);

--- a/hook/claude-notifier-on-stop.js
+++ b/hook/claude-notifier-on-stop.js
@@ -7,6 +7,7 @@ const { isMuted, isDisabled, readConfig } = require("./_lib/config");
 const { BUNDLED_FALLBACK } = require("./_lib/sounds");
 const { emitSound } = require("./_lib/emit");
 const { showNotification } = require("./_lib/notify");
+const { labelledMessage } = require("./_lib/session-label");
 const { extensionOwnsCwd } = require("./_lib/active");
 const { writeSignal } = require("./_lib/signal");
 const { getAncestorPids } = require("./_lib/pid");
@@ -65,7 +66,7 @@ process.stdin.on("end", () => {
   if (level === "sound+popup" || level === "popup") {
     // Stop notifications fire when the user is likely away — prefer
     // terminal-notifier so the click can focus VS Code.
-    showNotification("Claude has finished the task.", {
+    showNotification(labelledMessage(input, "finished", "Claude has finished the task."), {
       preferTerminalNotifier: true,
       executeCmd: buildClickAction(cwd) || GENERIC_ACTIVATE,
     });

--- a/hook/claude-notifier-on-subagent-stop.js
+++ b/hook/claude-notifier-on-subagent-stop.js
@@ -8,6 +8,7 @@ const { isMuted, isDisabled, readConfig } = require("./_lib/config");
 const { BUNDLED_FALLBACK } = require("./_lib/sounds");
 const { emitSound } = require("./_lib/emit");
 const { showNotification } = require("./_lib/notify");
+const { labelledMessage } = require("./_lib/session-label");
 const { extensionOwnsCwd } = require("./_lib/active");
 const { writeSignal } = require("./_lib/signal");
 const { shouldSuppressForThreshold } = require("./_lib/task-timer");
@@ -62,7 +63,7 @@ process.stdin.on("end", () => {
   }
 
   if (level === "sound+popup" || level === "popup") {
-    showNotification("Claude subagent finished.");
+    showNotification(labelledMessage(input, "subagent finished", "Claude subagent finished."));
   }
 
   process.exit(0);

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -4,6 +4,9 @@ export const HOME = process.env.HOME || process.env.USERPROFILE || "~";
 export const CLAUDE_DIR = path.join(HOME, ".claude");
 export const HOOKS_DIR = path.join(CLAUDE_DIR, "hooks");
 export const SETTINGS_FILE = path.join(CLAUDE_DIR, "settings.json");
+// Claude Code's own session transcripts, one directory per slugged cwd. Read
+// (never written) to resolve a session's title. See signals/session-label.ts.
+export const PROJECTS_DIR = path.join(CLAUDE_DIR, "projects");
 export const CONFIG_FILE = path.join(HOOKS_DIR, "claude-notifier-config.json");
 export const SIGNAL_FILE = path.join(HOOKS_DIR, "claude-signal");
 export const FOCUS_SIGNAL_FILE = path.join(HOOKS_DIR, "claude-notifier-focus");

--- a/src/signals/dispatch.ts
+++ b/src/signals/dispatch.ts
@@ -19,6 +19,7 @@ import { playLocalSound } from "../notifications/sound";
 import { showLocalNotification } from "../notifications/local";
 import { playRemoteSound, pushRemoteAudio } from "../notifications/remote";
 import { shouldSuppressForThreshold } from "./task-timer";
+import { buildSessionLabel } from "./session-label";
 
 let watcher: fs.FSWatcher | null = null;
 let deprecationLogged = false;
@@ -139,6 +140,19 @@ function showNotification(reason: string, cwd: string): void {
   // out of scope — the hook process can't see window focus.
   if (getAutoMuteWhenFocused() && vscode.window.state.focused) return;
 
+  // Name the session in every popup, so several concurrent sessions are
+  // tellable apart. Resolved lazily (it reads the session transcript) so the
+  // sound-only and "off" levels stay free, and memoised because a single
+  // notification can build more than one message. An empty label means nothing
+  // could be resolved, in which case each site keeps its original wording.
+  let label: string | undefined;
+  const message = (suffix: string, unlabelled: string): string => {
+    if (label === undefined) {
+      label = buildSessionLabel({ cwd, sessionId: lastSignalSessionId });
+    }
+    return label ? `${label} · ${suffix}` : unlabelled;
+  };
+
   // Architecture note: "question" and "input" local sounds are played by their
   // respective hook scripts (PreToolUse / PermissionRequest) — not the extension.
   // Only "done" local sounds are played here, because the extension is the
@@ -159,7 +173,9 @@ function showNotification(reason: string, cwd: string): void {
       playRemoteSound();
     }
     if (level === LEVELS.SOUND_POPUP || level === LEVELS.POPUP) {
-      vscode.window.showInformationMessage("Claude needs your permission.");
+      vscode.window.showInformationMessage(
+        message("needs permission", "Claude needs your permission.")
+      );
     }
   } else if (reason === "question") {
     const level = getEventLevel("asksQuestion");
@@ -175,7 +191,9 @@ function showNotification(reason: string, cwd: string): void {
       playRemoteSound();
     }
     if (level === LEVELS.SOUND_POPUP || level === LEVELS.POPUP) {
-      vscode.window.showInformationMessage("Claude is asking you a question.");
+      vscode.window.showInformationMessage(
+        message("asked you a question", "Claude is asking you a question.")
+      );
     }
   } else if (reason === "done") {
     const level = getEventLevel("taskCompleted");
@@ -197,14 +215,14 @@ function showNotification(reason: string, cwd: string): void {
     }
     if (level === LEVELS.SOUND_POPUP || level === LEVELS.POPUP) {
       vscode.window
-        .showInformationMessage("Claude has finished the task.", "Reveal")
+        .showInformationMessage(message("finished", "Claude has finished the task."), "Reveal")
         .then((pick) => {
           if (pick === "Reveal") {
             void revealClaudeTab(getRememberedDone(cwd));
           }
         });
       if (!isRemote) {
-        showLocalNotification("Claude has finished the task.", cwd);
+        showLocalNotification(message("finished", "Claude has finished the task."), cwd);
       }
     }
   } else if (reason === "subagent_done") {
@@ -226,7 +244,9 @@ function showNotification(reason: string, cwd: string): void {
       }
     }
     if (level === LEVELS.SOUND_POPUP || level === LEVELS.POPUP) {
-      vscode.window.showInformationMessage("Claude subagent finished.");
+      vscode.window.showInformationMessage(
+        message("subagent finished", "Claude subagent finished.")
+      );
     }
   }
 }

--- a/src/signals/session-label.ts
+++ b/src/signals/session-label.ts
@@ -1,0 +1,182 @@
+import * as fs from "fs";
+import * as path from "path";
+import { PROJECTS_DIR } from "../paths";
+
+/**
+ * Resolves a short label identifying WHICH Claude session an event came from,
+ * e.g. "my-repo · Fix the flaky login test".
+ *
+ * Claude Code writes an `ai-title` record into the session transcript at
+ * ~/.claude/projects/<slugged-cwd>/<session-id>.jsonl. That string is what its
+ * own session picker shows, so a label built from it maps directly onto the tab
+ * or session the user needs to open.
+ *
+ * Every function here fails soft and returns null/"" rather than throwing: the
+ * transcript layout is a Claude Code implementation detail, so callers must be
+ * able to fall back to an unlabelled message.
+ *
+ * hook/_lib/session-label.js is the parallel implementation used by the hook
+ * scripts, mirroring the src/routing/cwd.ts <-> hook/_lib/active.js split. Keep
+ * the two in sync.
+ */
+
+const MAX_TITLE = 70;
+/**
+ * Both the ai-title and the first user message are written near the start of a
+ * transcript, while transcripts themselves reach tens of MB. Reading only the
+ * head keeps this at ~1ms instead of ~110ms on a 28MB file, which matters
+ * because the extension calls it on the host thread for every notification.
+ */
+const HEAD_BYTES = 512 * 1024;
+const MAX_FULL_READ_BYTES = 64 * 1024 * 1024;
+
+export interface SessionLabelInput {
+  cwd?: string;
+  sessionId?: string | null;
+  /** Passed by Claude Code on hook stdin. Saves having to locate the file. */
+  transcriptPath?: string;
+  /** Override for tests. Defaults to ~/.claude/projects. */
+  projectsDir?: string;
+}
+
+function exists(p: string): boolean {
+  try {
+    return fs.existsSync(p);
+  } catch {
+    return false;
+  }
+}
+
+function collapse(value: string): string {
+  const flat = String(value).replace(/\s+/g, " ").trim();
+  return flat.length > MAX_TITLE ? `${flat.slice(0, MAX_TITLE - 1)}…` : flat;
+}
+
+/** Read at most `limit` bytes from the front of a file. */
+function readHead(filePath: string, limit: number): { text: string; truncated: boolean } | null {
+  let fd: number | undefined;
+  try {
+    fd = fs.openSync(filePath, "r");
+    const size = fs.fstatSync(fd).size;
+    const length = Math.min(size, limit);
+    const buf = Buffer.allocUnsafe(length);
+    fs.readSync(fd, buf, 0, length, 0);
+    return { text: buf.toString("utf-8"), truncated: size > length };
+  } catch {
+    return null;
+  } finally {
+    if (fd !== undefined) {
+      try {
+        fs.closeSync(fd);
+      } catch {
+        /* ignore */
+      }
+    }
+  }
+}
+
+function scanForTitle(text: string): string | null {
+  const lines = text.split("\n");
+
+  // Last ai-title wins: a long session can be re-titled. The substring test
+  // avoids JSON.parse on every line of a large transcript.
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const line = lines[i];
+    if (!line || !line.includes('"ai-title"')) continue;
+    try {
+      const parsed = JSON.parse(line);
+      if (parsed?.type === "ai-title" && parsed.aiTitle) return collapse(parsed.aiTitle);
+    } catch {
+      /* skip malformed line */
+    }
+  }
+
+  // Fallback for a session too young to have been titled yet.
+  for (const line of lines) {
+    if (!line.includes('"type":"user"')) continue;
+    try {
+      const parsed = JSON.parse(line);
+      if (parsed?.type !== "user" || !parsed.message) continue;
+      const content = parsed.message.content;
+      const text2: string =
+        typeof content === "string"
+          ? content
+          : Array.isArray(content)
+            ? (content.find((c: { type?: string }) => c?.type === "text")?.text ?? "")
+            : "";
+      // Skip injected <system-reminder> / <ide_selection> style turns.
+      if (text2 && !text2.trimStart().startsWith("<")) return collapse(text2);
+    } catch {
+      /* skip malformed line */
+    }
+  }
+  return null;
+}
+
+/** The session's ai-title, else the first thing the user typed, else null. */
+export function readSessionTitle(transcriptPath: string): string | null {
+  const head = readHead(transcriptPath, HEAD_BYTES);
+  if (!head) return null;
+
+  const fromHead = scanForTitle(head.text);
+  if (fromHead) return fromHead;
+  if (!head.truncated) return null;
+
+  // Nothing identifying in the head of a large file: pay for the full read.
+  try {
+    if (fs.statSync(transcriptPath).size > MAX_FULL_READ_BYTES) return null;
+    return scanForTitle(fs.readFileSync(transcriptPath, "utf-8"));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Locate a session transcript. The slug guess covers the normal case; the
+ * directory scan is the fallback for any cwd Claude Code slugs differently.
+ */
+export function findTranscript(
+  sessionId: string,
+  cwd?: string,
+  projectsDir: string = PROJECTS_DIR
+): string | null {
+  if (!sessionId || sessionId === "-") return null;
+  const fileName = `${sessionId}.jsonl`;
+
+  if (cwd) {
+    const guess = path.join(projectsDir, cwd.replace(/\//g, "-"), fileName);
+    if (exists(guess)) return guess;
+  }
+  let entries: string[];
+  try {
+    entries = fs.readdirSync(projectsDir);
+  } catch {
+    return null;
+  }
+  for (const entry of entries) {
+    const candidate = path.join(projectsDir, entry, fileName);
+    if (exists(candidate)) return candidate;
+  }
+  return null;
+}
+
+/**
+ * "<project> · <session title>", or just "<project>" when no title resolves,
+ * or "" when there is nothing to go on. Callers treat "" as "use the plain,
+ * unlabelled message" so behaviour is unchanged when a transcript is missing.
+ */
+export function buildSessionLabel(input: SessionLabelInput): string {
+  const { cwd, sessionId, transcriptPath, projectsDir = PROJECTS_DIR } = input;
+  const project = cwd ? path.basename(cwd.replace(/[\\/]+$/, "")) : "";
+
+  const transcript =
+    transcriptPath && exists(transcriptPath)
+      ? transcriptPath
+      : sessionId
+        ? findTranscript(sessionId, cwd, projectsDir)
+        : null;
+  const title = transcript ? readSessionTitle(transcript) : null;
+
+  if (project && title) return `${project} · ${title}`;
+  return title || project || "";
+}

--- a/test/hook/lib.session-label.test.ts
+++ b/test/hook/lib.session-label.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+
+// Set HOME before importing the lib (paths.js binds PROJECTS_DIR at module
+// load).
+const HOME_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "claude-notifier-hooklabel-"));
+const PROJECTS = path.join(HOME_DIR, ".claude", "projects");
+const CWD = path.join(path.sep, "home", "dev", "my-repo");
+const SLUG = CWD.split(path.sep).join("-");
+fs.mkdirSync(path.join(PROJECTS, SLUG), { recursive: true });
+
+const ORIG_HOME = process.env.HOME;
+process.env.HOME = HOME_DIR;
+
+const sessionLabel = await import("../../hook/_lib/session-label");
+
+function writeTranscript(sessionId: string, lines: unknown[]): string {
+  const file = path.join(PROJECTS, SLUG, `${sessionId}.jsonl`);
+  fs.writeFileSync(file, lines.map((l) => JSON.stringify(l)).join("\n"));
+  return file;
+}
+
+beforeAll(() => {
+  process.env.HOME = HOME_DIR;
+});
+afterAll(() => {
+  process.env.HOME = ORIG_HOME;
+  try {
+    fs.rmSync(HOME_DIR, { recursive: true, force: true });
+  } catch {}
+});
+
+describe("hook/_lib/session-label — buildSessionLabel", () => {
+  it("resolves project and title from the default projects dir", () => {
+    writeTranscript("h-both", [{ type: "ai-title", aiTitle: "Fix the flaky login test" }]);
+    expect(sessionLabel.buildSessionLabel({ cwd: CWD, sessionId: "h-both" })).toBe(
+      "my-repo · Fix the flaky login test"
+    );
+  });
+
+  it("degrades to the project name when the session is unknown", () => {
+    expect(sessionLabel.buildSessionLabel({ cwd: CWD, sessionId: "h-missing" })).toBe("my-repo");
+  });
+
+  it("returns empty string with no cwd and no session", () => {
+    expect(sessionLabel.buildSessionLabel({})).toBe("");
+  });
+
+  it("does not throw on a called-with-nothing invocation", () => {
+    expect(() => sessionLabel.buildSessionLabel()).not.toThrow();
+  });
+});
+
+describe("hook/_lib/session-label — labelledMessage", () => {
+  it("prefixes the label onto the suffix", () => {
+    writeTranscript("h-msg", [{ type: "ai-title", aiTitle: "Fix the flaky login test" }]);
+    const msg = sessionLabel.labelledMessage(
+      { cwd: CWD, session_id: "h-msg" },
+      "finished",
+      "Claude has finished the task."
+    );
+    expect(msg).toBe("my-repo · Fix the flaky login test · finished");
+  });
+
+  it("prefers transcript_path from stdin", () => {
+    const file = writeTranscript("h-stdin", [{ type: "ai-title", aiTitle: "From stdin" }]);
+    const msg = sessionLabel.labelledMessage(
+      { cwd: CWD, session_id: "h-stdin", transcript_path: file },
+      "finished",
+      "Claude has finished the task."
+    );
+    expect(msg).toBe("my-repo · From stdin · finished");
+  });
+
+  it("still labels with the project name when the session id is a placeholder", () => {
+    const msg = sessionLabel.labelledMessage(
+      { cwd: CWD, session_id: "-" },
+      "finished",
+      "Claude has finished the task."
+    );
+    expect(msg).toBe("my-repo · finished");
+  });
+
+  it("uses the unlabelled wording when no label can be built at all", () => {
+    // buildSessionLabel returns "" only when there is neither a project nor a
+    // title, which is what the extension side sees for a cwd-less signal.
+    expect(sessionLabel.buildSessionLabel({ cwd: "", sessionId: "-" })).toBe("");
+  });
+});

--- a/test/unit/signals.session-label.test.ts
+++ b/test/unit/signals.session-label.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import {
+  buildSessionLabel,
+  readSessionTitle,
+  findTranscript,
+} from "../../src/signals/session-label";
+
+const ROOT = fs.mkdtempSync(path.join(os.tmpdir(), "claude-notifier-label-"));
+const PROJECTS = path.join(ROOT, "projects");
+const CWD = path.join(path.sep, "home", "dev", "my-repo");
+// Claude Code slugs a cwd by replacing "/" with "-".
+const SLUG = CWD.split(path.sep).join("-");
+const SESSION = "aaaabbbb-1111-2222-3333-444455556666";
+
+function writeTranscript(dir: string, sessionId: string, lines: unknown[]): string {
+  const target = path.join(PROJECTS, dir);
+  fs.mkdirSync(target, { recursive: true });
+  const file = path.join(target, `${sessionId}.jsonl`);
+  fs.writeFileSync(file, lines.map((l) => JSON.stringify(l)).join("\n"));
+  return file;
+}
+
+beforeAll(() => {
+  fs.mkdirSync(PROJECTS, { recursive: true });
+});
+afterAll(() => {
+  try {
+    fs.rmSync(ROOT, { recursive: true, force: true });
+  } catch {
+    /* ignore */
+  }
+});
+
+describe("readSessionTitle", () => {
+  it("reads the ai-title record", () => {
+    const file = writeTranscript(SLUG, "t-title", [
+      { type: "user", message: { role: "user", content: "fix the login test" } },
+      { type: "ai-title", aiTitle: "Fix the flaky login test", sessionId: "t-title" },
+    ]);
+    expect(readSessionTitle(file)).toBe("Fix the flaky login test");
+  });
+
+  it("prefers the LAST ai-title, since a session can be re-titled", () => {
+    const file = writeTranscript(SLUG, "t-retitle", [
+      { type: "ai-title", aiTitle: "First guess", sessionId: "t-retitle" },
+      { type: "ai-title", aiTitle: "Better title", sessionId: "t-retitle" },
+    ]);
+    expect(readSessionTitle(file)).toBe("Better title");
+  });
+
+  it("falls back to the first user message before a title exists", () => {
+    const file = writeTranscript(SLUG, "t-young", [
+      { type: "user", message: { role: "user", content: "why is the build red" } },
+    ]);
+    expect(readSessionTitle(file)).toBe("why is the build red");
+  });
+
+  it("reads text out of a structured content array", () => {
+    const file = writeTranscript(SLUG, "t-array", [
+      { type: "user", message: { role: "user", content: [{ type: "text", text: "hello there" }] } },
+    ]);
+    expect(readSessionTitle(file)).toBe("hello there");
+  });
+
+  it("skips injected <system-reminder> turns", () => {
+    const file = writeTranscript(SLUG, "t-injected", [
+      {
+        type: "user",
+        message: { role: "user", content: "<system-reminder>ignore me</system-reminder>" },
+      },
+      { type: "user", message: { role: "user", content: "the real question" } },
+    ]);
+    expect(readSessionTitle(file)).toBe("the real question");
+  });
+
+  it("ignores malformed lines", () => {
+    const target = path.join(PROJECTS, SLUG);
+    fs.mkdirSync(target, { recursive: true });
+    const file = path.join(target, "t-malformed.jsonl");
+    fs.writeFileSync(file, '{not json at all\n{"type":"ai-title","aiTitle":"Survived"}\n');
+    expect(readSessionTitle(file)).toBe("Survived");
+  });
+
+  it("collapses whitespace and truncates a very long title", () => {
+    const file = writeTranscript(SLUG, "t-long", [
+      { type: "ai-title", aiTitle: `${"x".repeat(200)}\n  spread   out` },
+    ]);
+    const title = readSessionTitle(file)!;
+    expect(title.length).toBeLessThanOrEqual(70);
+    expect(title.endsWith("…")).toBe(true);
+  });
+
+  it("returns null for a missing file", () => {
+    expect(readSessionTitle(path.join(PROJECTS, "nope", "missing.jsonl"))).toBeNull();
+  });
+
+  it("returns null when nothing identifying is present", () => {
+    const file = writeTranscript(SLUG, "t-empty", [{ type: "assistant", message: {} }]);
+    expect(readSessionTitle(file)).toBeNull();
+  });
+});
+
+describe("findTranscript", () => {
+  it("finds it via the slugged cwd", () => {
+    const file = writeTranscript(SLUG, SESSION, [{ type: "ai-title", aiTitle: "Found" }]);
+    expect(findTranscript(SESSION, CWD, PROJECTS)).toBe(file);
+  });
+
+  it("falls back to scanning when the slug does not match", () => {
+    const file = writeTranscript("-some-other-slug", "s-scan", [
+      { type: "ai-title", aiTitle: "Found by scan" },
+    ]);
+    expect(findTranscript("s-scan", CWD, PROJECTS)).toBe(file);
+  });
+
+  it("returns null for an unknown session", () => {
+    expect(findTranscript("does-not-exist", CWD, PROJECTS)).toBeNull();
+  });
+
+  it("returns null for the '-' placeholder session id", () => {
+    expect(findTranscript("-", CWD, PROJECTS)).toBeNull();
+  });
+});
+
+describe("buildSessionLabel", () => {
+  it("combines project and title", () => {
+    writeTranscript(SLUG, "b-both", [{ type: "ai-title", aiTitle: "Fix the flaky login test" }]);
+    expect(buildSessionLabel({ cwd: CWD, sessionId: "b-both", projectsDir: PROJECTS })).toBe(
+      "my-repo · Fix the flaky login test"
+    );
+  });
+
+  it("uses an explicit transcriptPath when given", () => {
+    const file = writeTranscript("-unrelated", "b-explicit", [
+      { type: "ai-title", aiTitle: "From stdin path" },
+    ]);
+    expect(
+      buildSessionLabel({
+        cwd: CWD,
+        sessionId: "b-explicit",
+        transcriptPath: file,
+        projectsDir: PROJECTS,
+      })
+    ).toBe("my-repo · From stdin path");
+  });
+
+  it("degrades to the project name when no transcript resolves", () => {
+    expect(buildSessionLabel({ cwd: CWD, sessionId: "nothing-here", projectsDir: PROJECTS })).toBe(
+      "my-repo"
+    );
+  });
+
+  it("tolerates a trailing separator on cwd", () => {
+    expect(buildSessionLabel({ cwd: CWD + path.sep, projectsDir: PROJECTS })).toBe("my-repo");
+  });
+
+  it("returns empty string with nothing to go on, so callers keep their own wording", () => {
+    expect(buildSessionLabel({ projectsDir: PROJECTS })).toBe("");
+  });
+
+  it("does not throw when the projects directory is absent", () => {
+    expect(
+      buildSessionLabel({ cwd: CWD, sessionId: SESSION, projectsDir: path.join(ROOT, "absent") })
+    ).toBe("my-repo");
+  });
+});


### PR DESCRIPTION
## Summary

Every notification says the same thing today, so when several Claude sessions are running there is no way to tell which one wants you. This makes the popups name their session:

- `my-repo · Fix the flaky login test · finished`
- `my-repo · Verify database migration safety · needs permission for Bash`

The name is the `ai-title` record Claude Code writes into the session transcript, which is the same string its own session picker shows, so the label maps directly onto the tab you need to open. When no title can be resolved the previous wording is used unchanged, so nothing changes for single-session users.

Covers all five notification sites (stop, permission, question, subagent-stop, notification) on both the extension popup and the hook fallback.

## Test plan

- [x] `npm test` green locally (295 passing, 27 of them new)
- [x] `npm run typecheck && npm run lint && npm run format:check` green
- [x] `npm run smoke` green, but run on WSL2/Linux rather than macOS
- [ ] Sideloaded the produced `.vsix` into a fresh profile: not done, see notes
- [x] Drove the stop/permission/question hooks with synthetic stdin in a throwaway HOME and confirmed the labelled text

## Notes for reviewer

- **Where the title comes from.** `~/.claude/projects/<slugged-cwd>/<session-id>.jsonl`, last `ai-title` record, falling back to the first user message, then to just the project name, then to the existing unlabelled sentence. That layout is a Claude Code implementation detail, so every step fails soft and returns `""` rather than throwing. The transcript is only ever read, never written.
- **Only the head of the transcript is read** (512KB). Both signals appear near the start of a session, transcripts reach tens of MB, and `dispatch` runs this on the extension host thread. On a 28MB transcript that is about 1ms instead of 110ms. The label is also resolved lazily and memoised, so the `sound` and `off` levels do no I/O at all.
- **The duplication is deliberate.** `src/signals/session-label.ts` and `hook/_lib/session-label.js` are parallel implementations, following the existing `src/routing/cwd.ts` and `hook/_lib/active.js` split. Both are covered by their own tests.
- **No new setting.** The label replaces the generic sentence rather than sitting behind a toggle, on the grounds that it is strictly more information than before. Happy to put it behind something like `claudeNotifier.showSessionName`, or to change the format if you would rather keep the familiar sentence and append the session, for example `Claude has finished the task. — my-repo · Fix the flaky login test`.
- **CHANGELOG left alone** since releases look maintainer driven. Say the word and I will add an entry.
- I have not sideloaded a `.vsix` built from this branch. I did run the equivalent change against an installed 3.6.1 build for a full working day across a dozen-plus concurrent sessions, which is what prompted it.

Why I wrote this: I usually have ten to fifteen Claude sessions open across three windows, and "Claude has finished the task." tells me nothing about which one to go look at, so the notification was an alert rather than something I could act on. Putting the session name in it changed that completely, and it is the single thing that made the extension click for me. Thanks for building it.

Two smaller findings from the same debugging session I will send separately, per the one-per-PR guidance: hook notifications die silently on WSL when `wsl.conf` sets `interop.appendWindowsPath = false` (bare `powershell.exe` is not on `PATH`, and the failure is swallowed by a `catch {}`), and the Reveal button is a no-op for native Claude chat tabs.
