### PR TITLE
fix: escape sound paths in shell/PowerShell commands (#88)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- **No sound on Windows for users whose account name contains an apostrophe.** Both sound players built the PowerShell script by pasting the sound path into a single-quoted literal without doubling `'`, so a path like `C:\Users\O'Brien\.claude\hooks\_lib\sounds\complete.wav` — the bundled fallback, which lives under the home directory — produced a malformed script. Both call sites swallow errors, so the sound just silently didn't play. The path is now escaped for PowerShell. The macOS and Linux players had the same shape (the path was pasted into a double-quoted shell string, where `"`, `$`, `` ` `` and `\` are all live); macOS now spawns `afplay` without a shell at all, and Linux — which needs a shell to chain its three players with `||` — shell-quotes the path. ([#88](https://github.com/ashmitb95/claude-notifier/issues/88))
+
 ## [3.7.0] - 2026-08-19
 
 ### Added

--- a/hook/_lib/play.js
+++ b/hook/_lib/play.js
@@ -1,7 +1,17 @@
 const fs = require("fs");
-const { execSync } = require("child_process");
+const { execSync, execFileSync } = require("child_process");
 const { USE_WIN, IS_LINUX, PS_BIN } = require("./platform");
 const { isInsideCmux } = require("./cmux");
+
+// PowerShell single-quoted strings escape ' as ''. Anything else is literal.
+function psSingleQuoteEscape(s) {
+  return String(s).replace(/'/g, "''");
+}
+
+// POSIX single-quoted literal — nothing inside is special except ' itself.
+function shQuote(s) {
+  return `'${String(s).replace(/'/g, `'\\''`)}'`;
+}
 
 function clampVolume(v) {
   if (typeof v !== "number" || !Number.isFinite(v)) return 1;
@@ -32,7 +42,7 @@ function playSound(primaryPath, fallbackPath, volume = 1) {
   const v = clampVolume(volume);
   try {
     if (USE_WIN) {
-      const ps = `$s='${soundPath}'; if(Test-Path $s){(New-Object Media.SoundPlayer $s).PlaySync()}else{[console]::Beep(800,300)}`;
+      const ps = `$s='${psSingleQuoteEscape(soundPath)}'; if(Test-Path $s){(New-Object Media.SoundPlayer $s).PlaySync()}else{[console]::Beep(800,300)}`;
       execSync(
         `${PS_BIN} -NoProfile -NonInteractive -EncodedCommand ${Buffer.from(ps, "utf16le").toString("base64")}`,
         { stdio: "ignore", timeout: 5000 }
@@ -43,12 +53,16 @@ function playSound(primaryPath, fallbackPath, volume = 1) {
       // resort. pw-play --volume is a 0.0–1.0+ linear factor; paplay --volume a
       // 16-bit scale where 65536 = 100%.
       const paVolume = Math.round(v * 65536);
+      // Chaining the three players with || needs a shell, so the path is
+      // quoted rather than passed as an argv entry.
+      const q = shQuote(soundPath);
       execSync(
-        `pw-play --volume=${v} "${soundPath}" 2>/dev/null || paplay --volume=${paVolume} "${soundPath}" 2>/dev/null || aplay "${soundPath}" 2>/dev/null`,
+        `pw-play --volume=${v} ${q} 2>/dev/null || paplay --volume=${paVolume} ${q} 2>/dev/null || aplay ${q} 2>/dev/null`,
         { stdio: "ignore", timeout: 5000 }
       );
     } else {
-      execSync(`afplay -v ${v} "${soundPath}"`, { stdio: "ignore" });
+      // execFileSync bypasses the shell — no quoting concerns for the path.
+      execFileSync("afplay", ["-v", String(v), soundPath], { stdio: "ignore" });
     }
   } catch {}
 }

--- a/src/notifications/sound.ts
+++ b/src/notifications/sound.ts
@@ -1,6 +1,16 @@
-import { exec } from "child_process";
+import { exec, execFile } from "child_process";
 import { IS_WIN, IS_LINUX } from "../paths";
 import { clampVolume, DEFAULT_VOLUME } from "../settings/sync";
+
+// PowerShell single-quoted strings escape ' as ''. Anything else is literal.
+function psSingleQuoteEscape(s: string): string {
+  return s.replace(/'/g, "''");
+}
+
+// POSIX single-quoted literal — nothing inside is special except ' itself.
+function shQuote(s: string): string {
+  return `'${s.replace(/'/g, `'\\''`)}'`;
+}
 
 export const MACOS_SOUNDS: Record<string, string> = {
   Basso: "/System/Library/Sounds/Basso.aiff",
@@ -58,7 +68,7 @@ export function playLocalSound(
   if (IS_WIN) {
     // Media.SoundPlayer has no volume control; volume is ignored on Windows.
     const soundPath = WIN_SOUNDS[soundName] || defaultWin;
-    const ps = `$s='${soundPath}'; if(Test-Path $s){(New-Object Media.SoundPlayer $s).PlaySync()}else{[console]::Beep(800,300)}`;
+    const ps = `$s='${psSingleQuoteEscape(soundPath)}'; if(Test-Path $s){(New-Object Media.SoundPlayer $s).PlaySync()}else{[console]::Beep(800,300)}`;
     exec(
       `powershell -NoProfile -NonInteractive -EncodedCommand ${Buffer.from(ps, "utf16le").toString("base64")}`,
       { timeout: 5000 }
@@ -71,13 +81,17 @@ export function playLocalSound(
     // where 65536 = 100%; aplay has none, so it plays at system volume.
     const soundPath = LINUX_SOUNDS[soundName] || `${LINUX_SOUNDS_DIR}/complete.oga`;
     const paVolume = Math.round(v * 65536);
+    // Chaining the three players with || needs a shell, so the path is quoted
+    // rather than passed as an argv entry.
+    const q = shQuote(soundPath);
     exec(
-      `pw-play --volume=${v} "${soundPath}" 2>/dev/null || paplay --volume=${paVolume} "${soundPath}" 2>/dev/null || aplay "${soundPath}" 2>/dev/null`,
+      `pw-play --volume=${v} ${q} 2>/dev/null || paplay --volume=${paVolume} ${q} 2>/dev/null || aplay ${q} 2>/dev/null`,
       { timeout: 5000 }
     );
   } else {
-    // afplay -v takes a 0.0–2.0+ multiplier (1.0 = system volume).
+    // afplay -v takes a 0.0–2.0+ multiplier (1.0 = system volume). execFile
+    // bypasses the shell — no quoting concerns for the path.
     const soundPath = MACOS_SOUNDS[soundName] || defaultMac;
-    exec(`afplay -v ${v} "${soundPath}"`);
+    execFile("afplay", ["-v", String(v), soundPath]);
   }
 }

--- a/test/hook/lib.play.test.ts
+++ b/test/hook/lib.play.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { createRequire } from "module";
+import * as path from "path";
+
+// vi.mock() doesn't intercept CommonJS require(), and hook/_lib/play.js is CJS
+// — so stub the real child_process exports it destructures at load time.
+const nodeRequire = createRequire(__filename);
+const cp = nodeRequire("child_process");
+const realExecSync = cp.execSync;
+const realExecFileSync = cp.execFileSync;
+
+// Captured spawns: { cmd } for execSync, { file, args } for execFileSync.
+let spawns: Array<{ cmd?: string; file?: string; args?: string[] }> = [];
+
+const realPlatform = process.platform;
+
+function setPlatform(p: NodeJS.Platform): void {
+  Object.defineProperty(process, "platform", { value: p, configurable: true });
+}
+
+/** Load play.js fresh so hook/_lib/platform re-reads process.platform. */
+async function loadPlaySound() {
+  vi.resetModules();
+  // play.js require()s its siblings through Node, whose cache vi.resetModules()
+  // doesn't touch — platform.js would keep the flags from the previous test.
+  const libDir = `${path.sep}hook${path.sep}_lib${path.sep}`;
+  for (const key of Object.keys(nodeRequire.cache)) {
+    if (key.includes(libDir)) delete nodeRequire.cache[key];
+  }
+  const mod = await import("../../hook/_lib/play");
+  return mod.playSound as (p?: string, f?: string, v?: number) => void;
+}
+
+/** Recover the PowerShell script from a -EncodedCommand invocation. */
+function decodePS(cmd: string): string {
+  const b64 = cmd.split("-EncodedCommand ")[1];
+  return Buffer.from(b64!, "base64").toString("utf16le");
+}
+
+beforeEach(() => {
+  spawns = [];
+  cp.execSync = (cmd: string) => {
+    spawns.push({ cmd });
+    return Buffer.from("");
+  };
+  cp.execFileSync = (file: string, args: string[]) => {
+    spawns.push({ file, args });
+    return Buffer.from("");
+  };
+});
+
+afterEach(() => {
+  cp.execSync = realExecSync;
+  cp.execFileSync = realExecFileSync;
+  setPlatform(realPlatform);
+});
+
+// A bundled-fallback path under a home directory whose username has an
+// apostrophe — the reachable case from #88.
+const WIN_TRICKY = "C:\\Users\\O'Brien\\.claude\\hooks\\_lib\\sounds\\complete.wav";
+const POSIX_TRICKY = '/home/o\'brien/.claude/hooks/_lib/sounds/$(id)`whoami`"x".oga';
+
+describe("hook/_lib/play — Windows", () => {
+  it("doubles apostrophes in the sound path so the PowerShell literal stays intact", async () => {
+    setPlatform("win32");
+    const playSound = await loadPlaySound();
+    playSound(undefined, WIN_TRICKY);
+
+    expect(spawns).toHaveLength(1);
+    const ps = decodePS(spawns[0]!.cmd!);
+    expect(ps).toContain(`$s='C:\\Users\\O''Brien\\.claude\\hooks\\_lib\\sounds\\complete.wav'`);
+    // The literal must close exactly once — a lone ' would terminate it early.
+    expect(ps.split("'").length - 1).toBe(4);
+  });
+});
+
+describe("hook/_lib/play — Linux", () => {
+  it("shell-quotes the sound path in every chained player", async () => {
+    setPlatform("linux");
+    const playSound = await loadPlaySound();
+    playSound(undefined, POSIX_TRICKY);
+
+    expect(spawns).toHaveLength(1);
+    const cmd = spawns[0]!.cmd!;
+    const quoted = `'/home/o'\\''brien/.claude/hooks/_lib/sounds/$(id)\`whoami\`"x".oga'`;
+    expect(cmd).toContain(`pw-play --volume=1 ${quoted} 2>/dev/null`);
+    expect(cmd).toContain(`paplay --volume=65536 ${quoted} 2>/dev/null`);
+    expect(cmd).toContain(`aplay ${quoted} 2>/dev/null`);
+    // Nothing in the path may reach the shell unquoted.
+    expect(cmd).not.toContain(`"${POSIX_TRICKY}"`);
+  });
+});
+
+describe("hook/_lib/play — macOS", () => {
+  it("spawns afplay without a shell, passing the path as an argument", async () => {
+    setPlatform("darwin");
+    const playSound = await loadPlaySound();
+    playSound(undefined, POSIX_TRICKY, 0.5);
+
+    expect(spawns).toHaveLength(1);
+    expect(spawns[0]!.file).toBe("afplay");
+    expect(spawns[0]!.args).toEqual(["-v", "0.5", POSIX_TRICKY]);
+    expect(spawns[0]!.cmd).toBeUndefined();
+  });
+});

--- a/test/unit/notifications.sound.test.ts
+++ b/test/unit/notifications.sound.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Captured spawns: { cmd } for exec, { file, args } for execFile.
+let spawns: Array<{ cmd?: string; file?: string; args?: string[] }> = [];
+
+vi.mock("child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("child_process")>();
+  return {
+    ...actual,
+    exec: (cmd: string) => {
+      spawns.push({ cmd });
+    },
+    execFile: (file: string, args: string[]) => {
+      spawns.push({ file, args });
+    },
+  };
+});
+
+const realPlatform = process.platform;
+
+function setPlatform(p: NodeJS.Platform): void {
+  Object.defineProperty(process, "platform", { value: p, configurable: true });
+}
+
+/** Load sound.ts fresh so src/paths re-reads process.platform. */
+async function loadSound() {
+  vi.resetModules();
+  return await import("../../src/notifications/sound");
+}
+
+/** Recover the PowerShell script from a -EncodedCommand invocation. */
+function decodePS(cmd: string): string {
+  const b64 = cmd.split("-EncodedCommand ")[1];
+  return Buffer.from(b64, "base64").toString("utf16le");
+}
+
+beforeEach(() => {
+  spawns = [];
+});
+
+afterEach(() => {
+  setPlatform(realPlatform);
+});
+
+// A bundled-fallback path under a home directory whose username has an
+// apostrophe — the reachable case from #88.
+const WIN_TRICKY = "C:\\Users\\O'Brien\\.claude\\hooks\\_lib\\sounds\\complete.wav";
+const POSIX_TRICKY = '/home/o\'brien/sounds/$(id)`whoami`"x".oga';
+
+describe("playLocalSound — Windows", () => {
+  it("doubles apostrophes in the sound path so the PowerShell literal stays intact", async () => {
+    setPlatform("win32");
+    const { playLocalSound } = await loadSound();
+    playLocalSound("no-such-sound", "/mac.aiff", WIN_TRICKY);
+
+    expect(spawns).toHaveLength(1);
+    const ps = decodePS(spawns[0].cmd!);
+    expect(ps).toContain(`$s='C:\\Users\\O''Brien\\.claude\\hooks\\_lib\\sounds\\complete.wav'`);
+    // The literal must close exactly once — a lone ' would terminate it early.
+    expect(ps.split("'").length - 1).toBe(4);
+  });
+});
+
+describe("playLocalSound — Linux", () => {
+  it("shell-quotes the sound path in every chained player", async () => {
+    setPlatform("linux");
+    const { playLocalSound, LINUX_SOUNDS } = await loadSound();
+    LINUX_SOUNDS.Tricky = POSIX_TRICKY;
+    playLocalSound("Tricky", "/mac.aiff", "C:\\win.wav");
+
+    expect(spawns).toHaveLength(1);
+    const cmd = spawns[0].cmd!;
+    const quoted = `'/home/o'\\''brien/sounds/$(id)\`whoami\`"x".oga'`;
+    expect(cmd).toContain(`pw-play --volume=1 ${quoted} 2>/dev/null`);
+    expect(cmd).toContain(`paplay --volume=65536 ${quoted} 2>/dev/null`);
+    expect(cmd).toContain(`aplay ${quoted} 2>/dev/null`);
+    // Nothing in the path may reach the shell unquoted.
+    expect(cmd).not.toContain(`"${POSIX_TRICKY}"`);
+  });
+});
+
+describe("playLocalSound — macOS", () => {
+  it("spawns afplay without a shell, passing the path as an argument", async () => {
+    setPlatform("darwin");
+    const { playLocalSound } = await loadSound();
+    playLocalSound("no-such-sound", POSIX_TRICKY, "C:\\win.wav", 0.5);
+
+    expect(spawns).toHaveLength(1);
+    expect(spawns[0].file).toBe("afplay");
+    expect(spawns[0].args).toEqual(["-v", "0.5", POSIX_TRICKY]);
+    expect(spawns[0].cmd).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Fixes #88.

## Problem

Both sound players built their PowerShell script by pasting the sound path into a single-quoted literal without doubling `'`:

```js
const ps = `$s='${soundPath}'; if(Test-Path $s){...}`;
```

The bundled fallback sound lives under the home directory (`~/.claude/hooks/_lib/sounds/`), so on Windows any account name containing an apostrophe — `C:\Users\O'Brien\...` — closed the literal early and produced a malformed script. Both call sites swallow errors, so the symptom was just: no sound, no message.

The macOS and Linux branches had the same shape — the path was interpolated into a double-quoted shell string, where `"`, `$`, `` ` `` and `\` are all live. Not reachable today (`resolveSound` only returns entries from fixed tables), but fragile the moment a user-supplied sound path is accepted.

## Fix

`hook/_lib/play.js` and `src/notifications/sound.ts` each get local `psSingleQuoteEscape` / `shQuote` helpers, matching the ones already in `hook/_lib/notify.js` and `hook/_lib/click.js`:

- **Windows** — the path is escaped before it goes into the `$s='…'` literal.
- **macOS** — `afplay` is spawned via `execFileSync` / `execFile` with an args array, dropping the shell entirely.
- **Linux** — keeps a shell (it chains pw-play/paplay/aplay with `||`) and shell-quotes the path in all three positions.

`hook/_lib.ps1` was already safe: it passes the path as a PowerShell variable rather than interpolating it into a script string.

## Tests

New `test/hook/lib.play.test.ts` and `test/unit/notifications.sound.test.ts` stub the spawn functions, force each platform, and assert on the exact command constructed — including that the PowerShell literal closes exactly once and that the raw path never appears unquoted. Six tests, failing before the fix.

One wrinkle for future readers: `vi.mock("child_process")` does not intercept CommonJS `require()`, so the hook-lib test patches the real `child_process` exports and clears Node's require cache for `hook/_lib/*` between platform switches.

## Verification

- `npm test` — 155 unit + 132 hook tests pass
- `npm run typecheck`, `npm run lint`, `npm run format:check` clean
- Real playback smoke-tested on macOS through the new `execFileSync` path
- Confirmed `execFile` without a callback does not throw on a missing binary, so the extension-side change can't crash the host if `afplay` is absent

## Out of scope

`daemon/main.go:94` has the identical Linux shell-interpolation shape, but its paths come only from fixed tables with no home-directory component, so it isn't reachable. 
Cleanup later.
