### PR TITLE
Codex support (4.0.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [3.8.0] - 2026-08-19
+
+### Added
+
+- **Codex support.** Codex sessions now drive the same notification pipeline as Claude Code — the same sounds, per-event levels, mute, auto-mute, threshold, dedup, and remote audio. Codex's hook system turns out to be a close clone of Claude Code's, down to the payload field names (`cwd`, `session_id`, `stop_hook_active`), so the existing hook scripts serve both agents; they take an `--agent` argument that only decides how notifications are worded. The extension registers `Stop`, `PermissionRequest`, `UserPromptSubmit`, and `SubagentStop` in `~/.codex/hooks.json` (honouring `CODEX_HOME`), merging alongside any hooks another tool registered and leaving them intact. Registration is skipped entirely when Codex isn't installed, so no `~/.codex` directory is created for users who don't have it; `claudeNotifier.codex.enabled` opts out otherwise. Notifier state — signal file, config, mute flag, active markers — stays in `~/.claude/hooks/` for every agent, so there is still one signal file and one watcher. Codex has no `AskUserQuestion` analog, so `asksQuestion` remains Claude-Code-only. Setup and troubleshooting: [docs/CODEX.md](docs/CODEX.md). ([#83](https://github.com/ashmitb95/claude-notifier/issues/83))
+
+  Codex gates newly registered hooks behind a trust prompt, and the extension deliberately does not grant that trust on the user's behalf — it could, since trust is just a hash recorded in `config.toml`, but that would defeat a control Codex added on purpose. Because Codex pins trust to a hash of the *registration entry* rather than the script contents, approving once survives extension upgrades that rewrite the scripts; the registered command line is kept byte-stable to preserve that. Our entry is registered first for each event so a third-party hook appearing later can't shift the index its trust key is derived from.
+
+### Changed
+
+- **Renamed to "Claude & Codex Notifier"** on the Marketplace. The extension ID (`SingularityInc.claude-notifier`), all command IDs, and every `claudeNotifier.*` setting key are unchanged, so installs, ratings, keybindings, and existing settings all carry over untouched. Added the `keywords` the manifest had never declared, and an explicit note that this is an independent extension not affiliated with Anthropic or OpenAI.
+
 ## [3.7.0] - 2026-08-19
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Changed
 
-- **Renamed to "Claude & Codex Notifier"** on the Marketplace. The extension ID (`SingularityInc.claude-notifier`), all command IDs, and every `claudeNotifier.*` setting key are unchanged, so installs, ratings, keybindings, and existing settings all carry over untouched. Added the `keywords` the manifest had never declared, and an explicit note that this is an independent extension not affiliated with Anthropic or OpenAI.
+- Added the `keywords` the manifest had never declared, and an explicit note that this is an independent extension not affiliated with Anthropic or OpenAI. The Marketplace title is unchanged for now.
 
 ## [3.7.0] - 2026-08-19
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Claude & Codex Notifier
+# Claude Notifier
 
 [![VS Marketplace](https://img.shields.io/visual-studio-marketplace/v/SingularityInc.claude-notifier)](https://marketplace.visualstudio.com/items?itemName=SingularityInc.claude-notifier)
 [![Ko-fi](https://img.shields.io/badge/Ko--fi-support-ff5e5b?logo=ko-fi&logoColor=white)](https://ko-fi.com/ashmitb95)

--- a/README.md
+++ b/README.md
@@ -1,13 +1,17 @@
-# Claude Notifier
+# Claude & Codex Notifier
 
 [![VS Marketplace](https://img.shields.io/visual-studio-marketplace/v/SingularityInc.claude-notifier)](https://marketplace.visualstudio.com/items?itemName=SingularityInc.claude-notifier)
 [![Ko-fi](https://img.shields.io/badge/Ko--fi-support-ff5e5b?logo=ko-fi&logoColor=white)](https://ko-fi.com/ashmitb95)
 
-Plays a sound and shows a notification when [Claude Code](https://claude.com/claude-code) finishes a task, needs permission, or asks a question.
+Plays a sound and shows a notification when [Claude Code](https://claude.com/claude-code) or [Codex](https://developers.openai.com/codex) finishes a task, needs permission, or asks a question.
 
-Stop watching the screen — go grab a coffee and let Claude ping you when it needs you.
+Stop watching the screen — go grab a coffee and let your agent ping you when it needs you.
 
-Works with **VSCode**, **terminal CLI**, **vim**, or any editor where you use Claude Code — on **macOS**, **Windows**, **WSL**, and **Linux**, including **remote hosts over SSH**.
+Works with **VSCode**, **terminal CLI**, **vim**, or any editor where you use Claude Code or Codex — on **macOS**, **Windows**, **WSL**, and **Linux**, including **remote hosts over SSH**.
+
+## What's new — 3.8.0
+
+- **Codex support.** Codex sessions now drive the same notifications as Claude Code — same sounds, same per-event levels, same mute and auto-mute behaviour. The extension registers hooks in `~/.codex/hooks.json` when it finds Codex installed, and does nothing at all when it doesn't. Codex asks you to trust the hooks once before they start firing. See **[docs/CODEX.md](docs/CODEX.md)**. ([#83](https://github.com/ashmitb95/claude-notifier/issues/83))
 
 ## What's new — 3.7.1
 
@@ -101,6 +105,14 @@ A dedicated `SubagentStop` hook fires when a `Task` subagent finishes. The level
 - **Defers to other notification hosts.** Inside VS Code, the extension takes over from the hook fallback for the owning window. Inside [cmux](https://github.com/manaflow-ai/cmux), the hook detects cmux's `CMUX_CLAUDE_HOOK_CMUX_BIN` env var and skips its own sound + popup so cmux's native banner doesn't get double-stacked. Inside [Cursor](https://cursor.com) — which runs `~/.claude/settings.json` hooks from its own Composer agent — the hook detects Cursor's `CURSOR_*` environment and stays silent, so you don't get a notification for work that isn't a Claude Code session.
 - **Diagnostic log.** `View → Output → Claude Notifier` shows activation, signal receipts, dedup decisions, and configuration warnings — useful when debugging "I didn't get a notification."
 
+### Codex
+
+Codex sessions run through the same pipeline as Claude Code. The extension registers its hooks in `~/.codex/hooks.json` when it finds Codex installed; if you don't have Codex, no `~/.codex` directory is created. Opt out with `claudeNotifier.codex.enabled`.
+
+**Codex asks you to trust the hooks once** before it will run them — until you approve, Codex sessions stay silent. The extension doesn't grant that trust for you. You only approve once; extension upgrades don't re-trigger the prompt.
+
+The one gap is the "asks a question" sound: Codex has no `AskUserQuestion` equivalent, so that event only fires for Claude Code. Full detail in **[docs/CODEX.md](docs/CODEX.md)**.
+
 ### Clickable macOS notifications (optional)
 
 By default, macOS attributes `osascript` notifications to the Script Editor bundle, so clicking one opens Script Editor instead of focusing VS Code. To get clickable notifications that focus the specific window the notification fired from, install [`terminal-notifier`](https://github.com/julienXX/terminal-notifier):
@@ -159,3 +171,7 @@ Thanks to everyone who has contributed to this project:
 ## License
 
 [GPL-3.0](LICENSE.md)
+
+---
+
+An independent, community-built extension. Not affiliated with, endorsed by, or sponsored by Anthropic or OpenAI. "Claude" is a trademark of Anthropic; "Codex" is a trademark of OpenAI.

--- a/docs/CODEX.md
+++ b/docs/CODEX.md
@@ -1,0 +1,79 @@
+# Codex support
+
+Claude Notifier also notifies for [Codex](https://developers.openai.com/codex) sessions. Codex's
+hook system is close enough to Claude Code's that both agents drive the same notification pipeline —
+the same sounds, the same per-event levels, the same mute and auto-mute behaviour.
+
+## How it works
+
+On activation the extension writes its hook registration to `~/.codex/hooks.json` (or
+`$CODEX_HOME/hooks.json`). The hooks it registers are the same scripts it installs for Claude Code,
+in `~/.claude/hooks/`, invoked with `--agent codex` so notifications are worded correctly.
+
+Everything downstream is shared: one signal file, one config file, one mute flag, one watcher,
+regardless of how many agents are installed.
+
+If you don't have Codex, nothing happens — no `~/.codex` directory is created. Set
+`claudeNotifier.codex.enabled` to `false` to opt out even when Codex is present.
+
+## Trusting the hooks
+
+**Codex will not run a newly registered hook until you trust it.** The first time the extension
+writes `hooks.json`, Codex shows the hooks as untrusted and asks you to approve them. Until you do,
+Codex sessions stay silent.
+
+The extension does not grant that trust on your behalf. It could — trust is just a hash recorded in
+`config.toml` — but that would defeat a control Codex added deliberately, and it would break the
+moment OpenAI hardens it.
+
+You only have to approve once. Codex pins trust to a hash of the *registration entry*, not of the
+hook script's contents, so extension upgrades that change the scripts do not re-trigger the prompt.
+The entry is deliberately kept byte-stable across releases for this reason — see the comment on
+`hookCmd` in [`src/hooks/cmd.ts`](../src/hooks/cmd.ts).
+
+Two things do invalidate trust and require re-approving:
+
+- Changing `claudeNotifier.codex.enabled` off and on again in a release where the command line
+  changed.
+- Another tool inserting its own hooks *ahead* of ours in `hooks.json`, which shifts our index and
+  therefore our trust key. We register ourselves first for each event to make this unlikely.
+
+## Event coverage
+
+| Notifier event | Claude Code | Codex |
+| --- | --- | --- |
+| `taskCompleted` | `Stop` | `Stop` |
+| `needsPermission` | `PermissionRequest` | `PermissionRequest` |
+| `subagentCompleted` | `SubagentStop` | `SubagentStop` |
+| (internal staging) | `UserPromptSubmit` | `UserPromptSubmit` |
+| `asksQuestion` | `PreToolUse` / `AskUserQuestion` | — no equivalent |
+
+Codex has no `AskUserQuestion` tool, so the "asks a question" sound never fires for Codex sessions.
+The setting still applies to Claude Code.
+
+## Known limitations
+
+- **Hooks run synchronously.** Codex waits for a command hook to exit; unlike its metadata model,
+  the `hooks.json` format exposes no way to request async execution. Ours only write a signal file
+  and return, and we register a 10-second timeout to bound the worst case.
+- **Windows notifications say "Claude".** The PowerShell hook scripts don't read `--agent`. In
+  practice Codex steers Windows users to WSL, which uses the Node scripts and labels correctly.
+- **Notifier state lives under `~/.claude/hooks/`** even for Codex-only users, because that is where
+  the shared signal file and config already live.
+
+## Troubleshooting
+
+`View → Output → Claude Notifier` logs whether the Codex registration was written.
+
+To see what Codex itself makes of the registration — including trust status and any parse errors —
+ask its app server directly:
+
+```bash
+codex app-server <<'EOF'
+{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"clientInfo":{"name":"probe","version":"1"}}}
+{"jsonrpc":"2.0","id":2,"method":"hooks/list","params":{"cwds":["/path/to/your/project"]}}
+EOF
+```
+
+Each entry reports `trustStatus` (`trusted`, `untrusted`, or `modified`) and `timeoutSec`. A
+`modified` status means the registration changed since you approved it and needs re-approving.

--- a/hook/_lib/agent.js
+++ b/hook/_lib/agent.js
@@ -1,0 +1,15 @@
+// Which agent invoked this hook. Registrations for agents other than Claude
+// Code pass `--agent <id>`; a bare invocation is Claude Code.
+const LABELS = { claude: "Claude", codex: "Codex" };
+
+function agentId() {
+  const i = process.argv.indexOf("--agent");
+  const id = i >= 0 ? process.argv[i + 1] : "";
+  return Object.prototype.hasOwnProperty.call(LABELS, id) ? id : "claude";
+}
+
+function agentLabel() {
+  return LABELS[agentId()];
+}
+
+module.exports = { agentId, agentLabel };

--- a/hook/claude-notifier-on-permission.js
+++ b/hook/claude-notifier-on-permission.js
@@ -9,6 +9,7 @@ const { titleForCwd } = require("./_lib/title");
 const { writeSignal } = require("./_lib/signal");
 const { buildClickAction, GENERIC_ACTIVATE } = require("./_lib/click");
 const { shouldSuppressForThreshold } = require("./_lib/task-timer");
+const { agentLabel } = require("./_lib/agent");
 
 let raw = "";
 process.stdin.setEncoding("utf-8");
@@ -68,7 +69,7 @@ process.stdin.on("end", () => {
   if (level === "sound+popup" || level === "popup") {
     const tool = input.tool_name || "a tool";
     const cwd = (input && input.cwd) || process.cwd() || "";
-    showNotification(`Claude needs permission to use ${tool}.`, {
+    showNotification(`${agentLabel()} needs permission to use ${tool}.`, {
       title: titleForCwd(cwd),
       preferTerminalNotifier: true,
       executeCmd: buildClickAction(cwd) || GENERIC_ACTIVATE,

--- a/hook/claude-notifier-on-stop.js
+++ b/hook/claude-notifier-on-stop.js
@@ -13,6 +13,7 @@ const { writeSignal } = require("./_lib/signal");
 const { getAncestorPids } = require("./_lib/pid");
 const { buildClickAction, GENERIC_ACTIVATE } = require("./_lib/click");
 const { shouldSuppressForThreshold } = require("./_lib/task-timer");
+const { agentLabel } = require("./_lib/agent");
 
 let raw = "";
 process.stdin.setEncoding("utf-8");
@@ -66,7 +67,7 @@ process.stdin.on("end", () => {
   if (level === "sound+popup" || level === "popup") {
     // Stop notifications fire when the user is likely away — prefer
     // terminal-notifier so the click can focus VS Code.
-    showNotification("Claude has finished the task.", {
+    showNotification(`${agentLabel()} has finished the task.`, {
       title: titleForCwd(cwd),
       preferTerminalNotifier: true,
       executeCmd: buildClickAction(cwd) || GENERIC_ACTIVATE,

--- a/hook/claude-notifier-on-subagent-stop.js
+++ b/hook/claude-notifier-on-subagent-stop.js
@@ -12,6 +12,7 @@ const { titleForCwd } = require("./_lib/title");
 const { extensionOwnsCwd } = require("./_lib/active");
 const { writeSignal } = require("./_lib/signal");
 const { shouldSuppressForThreshold } = require("./_lib/task-timer");
+const { agentLabel } = require("./_lib/agent");
 
 let raw = "";
 process.stdin.setEncoding("utf-8");
@@ -63,7 +64,7 @@ process.stdin.on("end", () => {
   }
 
   if (level === "sound+popup" || level === "popup") {
-    showNotification("Claude subagent finished.", { title: titleForCwd(cwd) });
+    showNotification(`${agentLabel()} subagent finished.`, { title: titleForCwd(cwd) });
   }
 
   process.exit(0);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-notifier",
-  "version": "3.6.1",
+  "version": "3.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-notifier",
-      "version": "3.6.1",
+      "version": "3.8.0",
       "devDependencies": {
         "@eslint/js": "^10.0.1",
         "@types/node": "^20.0.0",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "claude-notifier",
-  "displayName": "Claude Notifier",
-  "description": "Plays distinct sounds when Claude Code finishes a task or needs your input",
-  "version": "3.7.1",
+  "displayName": "Claude & Codex Notifier",
+  "description": "Plays distinct sounds when Claude Code or Codex finishes a task or needs your input",
+  "version": "3.8.0",
   "icon": "media/icon.png",
   "publisher": "SingularityInc",
   "repository": {
@@ -62,7 +62,7 @@
       }
     ],
     "configuration": {
-      "title": "Claude Notifier",
+      "title": "Claude & Codex Notifier",
       "properties": {
         "claudeNotifier.taskCompleted.level": {
           "type": "string",
@@ -280,6 +280,11 @@
           "deprecationMessage": "Deprecated and ignored. Per-session stage dedup replaces it. Safe to delete from your settings.",
           "description": "Deprecated and ignored. Per-session stage dedup handles rapid 'done' signal coalescing."
         },
+        "claudeNotifier.codex.enabled": {
+          "type": "boolean",
+          "default": true,
+          "markdownDescription": "Also notify for [Codex](https://developers.openai.com/codex) sessions by registering hooks in `~/.codex/hooks.json`. Has no effect when Codex isn't installed — no `~/.codex` directory is created. Codex asks you to trust the hooks once before they run; see [docs/CODEX.md](https://github.com/ashmitb95/claude-notifier/blob/main/docs/CODEX.md)."
+        },
         "claudeNotifier.remoteAudio.enabled": {
           "type": "boolean",
           "default": false,
@@ -324,5 +329,17 @@
     "typescript": "^5.3.0",
     "typescript-eslint": "^8.60.1",
     "vitest": "^4.1.6"
-  }
+  },
+  "keywords": [
+    "claude",
+    "claude code",
+    "codex",
+    "openai",
+    "anthropic",
+    "notification",
+    "sound",
+    "alert",
+    "agent",
+    "ai"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-notifier",
-  "displayName": "Claude & Codex Notifier",
+  "displayName": "Claude Notifier",
   "description": "Plays distinct sounds when Claude Code or Codex finishes a task or needs your input",
   "version": "3.8.0",
   "icon": "media/icon.png",
@@ -62,7 +62,7 @@
       }
     ],
     "configuration": {
-      "title": "Claude & Codex Notifier",
+      "title": "Claude Notifier",
       "properties": {
         "claudeNotifier.taskCompleted.level": {
           "type": "string",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,6 +3,7 @@ import * as vscode from "vscode";
 import { ACTIVE_DIR, OWN_PID_FILE } from "./paths";
 import { syncConfig } from "./settings/sync";
 import { setupHooks } from "./hooks/lifecycle";
+import { setupCodexIfEnabled } from "./hooks/codex-setup";
 import { initDiscovery, installTerminalNotifierFlow } from "./notifications/terminal-notifier";
 import { writeOwnPidFile, cleanStalePidFiles } from "./routing/cwd";
 import { startFocusSignalWatcher } from "./routing/focus";
@@ -24,6 +25,7 @@ export function activate(context: vscode.ExtensionContext) {
   initLogger(context);
   log("activate: extensionPath=", context.extensionPath);
   setupHooks(context.extensionPath);
+  setupCodexIfEnabled();
   syncConfig();
   cleanupStaleMarkers(24 * 60 * 60 * 1000);
   initDiscovery();

--- a/src/hooks/cmd.ts
+++ b/src/hooks/cmd.ts
@@ -1,8 +1,16 @@
 import { IS_WIN } from "../paths";
 
-export function hookCmd(hookPath: string): string {
+/**
+ * Shell command that runs a hook script. `agent` is appended for agents other
+ * than Claude Code so the script can word its notifications correctly.
+ *
+ * Codex pins hook trust to a hash of this string, so it must stay byte-stable
+ * across extension upgrades — see docs/CODEX.md.
+ */
+export function hookCmd(hookPath: string, agent?: string): string {
+  const arg = agent ? ` --agent ${agent}` : "";
   if (IS_WIN) {
-    return `powershell -NoProfile -NonInteractive -ExecutionPolicy Bypass -File "${hookPath}"`;
+    return `powershell -NoProfile -NonInteractive -ExecutionPolicy Bypass -File "${hookPath}"${arg}`;
   }
-  return `node "${hookPath}"`;
+  return `node "${hookPath}"${arg}`;
 }

--- a/src/hooks/codex-setup.ts
+++ b/src/hooks/codex-setup.ts
@@ -1,0 +1,39 @@
+import * as vscode from "vscode";
+import { log } from "../log";
+import { CODEX_HOOKS_FILE } from "../paths";
+import { setupCodexHooks } from "./codex";
+
+/**
+ * Register hooks with Codex when the user has it installed and hasn't opted
+ * out. Codex will not run newly-registered hooks until the user trusts them,
+ * so a first write is worth telling them about — otherwise Codex stays silent
+ * with no visible reason why.
+ */
+export function setupCodexIfEnabled(): void {
+  if (!vscode.workspace.getConfiguration("claudeNotifier").get<boolean>("codex.enabled", true)) {
+    return;
+  }
+  let wrote = false;
+  try {
+    wrote = setupCodexHooks();
+  } catch (err) {
+    log("codex: hook registration failed:", String(err));
+    return;
+  }
+  if (!wrote) return;
+
+  log("codex: wrote hook registration to", CODEX_HOOKS_FILE);
+  vscode.window
+    .showInformationMessage(
+      "Claude Notifier registered its hooks with Codex. Codex will ask you to trust them before " +
+        "notifications start working.",
+      "Learn more"
+    )
+    .then((choice) => {
+      if (choice === "Learn more") {
+        vscode.env.openExternal(
+          vscode.Uri.parse("https://github.com/ashmitb95/claude-notifier/blob/main/docs/CODEX.md")
+        );
+      }
+    });
+}

--- a/src/hooks/codex.ts
+++ b/src/hooks/codex.ts
@@ -1,0 +1,125 @@
+import * as fs from "fs";
+import { CODEX_DIR, CODEX_HOOKS_FILE } from "../paths";
+import { HOOKS, hookDestPath } from "./registry";
+import { hookCmd } from "./cmd";
+
+export const CODEX_AGENT = "codex";
+
+/** Marker identifying our entries inside a hooks.json we do not own. */
+const OURS = "claude-notifier-on-";
+
+/**
+ * Codex runs command hooks synchronously and waits for them, with a default
+ * timeout of 600s. Ours only write a signal file and return, so a short cap
+ * bounds how long a wedged hook could stall a turn.
+ */
+const HOOK_TIMEOUT_SEC = 10;
+
+type CodexHookEntry = { type: string; command?: string; [k: string]: unknown };
+type CodexGroup = { matcher?: string; hooks?: CodexHookEntry[] };
+type CodexHooksFile = { hooks?: Record<string, CodexGroup[]>; [k: string]: unknown };
+
+/** Hooks that map onto a Codex event. Codex has no AskUserQuestion analog. */
+export function codexHooks() {
+  return HOOKS.filter((hook) => hook.codexType);
+}
+
+function isOurs(group: CodexGroup): boolean {
+  return (
+    group.hooks?.some((h) => typeof h.command === "string" && h.command.includes(OURS)) ?? false
+  );
+}
+
+function readHooksFile(): CodexHooksFile {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(CODEX_HOOKS_FILE, "utf-8"));
+    return parsed && typeof parsed === "object" ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Strip our entries from a parsed hooks.json, leaving anything the user or
+ * another tool registered. Mutates `file` in place.
+ */
+export function stripCodexNotifierHooks(file: CodexHooksFile): void {
+  if (!file.hooks || typeof file.hooks !== "object") return;
+  for (const event of Object.keys(file.hooks)) {
+    const groups = file.hooks[event];
+    if (!Array.isArray(groups)) continue;
+    const kept = groups.filter((group) => !isOurs(group));
+    if (kept.length === 0) {
+      delete file.hooks[event];
+    } else {
+      file.hooks[event] = kept;
+    }
+  }
+}
+
+/** The hooks.json content we want on disk, given whatever is already there. */
+export function buildCodexHooksFile(existing: CodexHooksFile): CodexHooksFile {
+  const file: CodexHooksFile = { ...existing };
+  file.hooks = { ...(existing.hooks ?? {}) };
+  stripCodexNotifierHooks(file);
+
+  for (const hook of codexHooks()) {
+    const event = hook.codexType as string;
+    const entry: CodexGroup = {
+      hooks: [
+        {
+          type: "command",
+          command: hookCmd(hookDestPath(hook), CODEX_AGENT),
+          timeout: HOOK_TIMEOUT_SEC,
+        },
+      ],
+    };
+    // Ours goes first: Codex derives a hook's trust key from its index within
+    // the event, so leading position keeps that key stable when another tool
+    // appends its own hooks later.
+    file.hooks[event] = [entry, ...(file.hooks[event] ?? [])];
+  }
+  return file;
+}
+
+/**
+ * Register our hooks in ~/.codex/hooks.json. No-ops when Codex is not
+ * installed, so users without Codex never get a ~/.codex directory.
+ *
+ * Returns true when the file was written (first install or a changed command),
+ * which is the caller's cue that Codex will ask the user to trust the hooks.
+ */
+export function setupCodexHooks(): boolean {
+  if (!fs.existsSync(CODEX_DIR)) return false;
+
+  const existing = readHooksFile();
+  const desired = buildCodexHooksFile(existing);
+  const next = JSON.stringify(desired, null, 2) + "\n";
+
+  let current = "";
+  try {
+    current = fs.readFileSync(CODEX_HOOKS_FILE, "utf-8");
+  } catch {}
+  if (current === next) return false;
+
+  fs.writeFileSync(CODEX_HOOKS_FILE, next);
+  return true;
+}
+
+/** Remove our entries, deleting the file if nothing else is left in it. */
+export function teardownCodexHooks(): void {
+  if (!fs.existsSync(CODEX_HOOKS_FILE)) return;
+  const file = readHooksFile();
+  stripCodexNotifierHooks(file);
+
+  const empty =
+    Object.keys(file).length === 0 ||
+    (Object.keys(file).length === 1 && Object.keys(file.hooks ?? {}).length === 0);
+  try {
+    if (empty) {
+      fs.unlinkSync(CODEX_HOOKS_FILE);
+    } else {
+      fs.writeFileSync(CODEX_HOOKS_FILE, JSON.stringify(file, null, 2) + "\n");
+    }
+  } catch {}
+}

--- a/src/hooks/lifecycle.ts
+++ b/src/hooks/lifecycle.ts
@@ -12,6 +12,7 @@ import {
 import { HOOKS, hookDestPath } from "./registry";
 import { hookCmd } from "./cmd";
 import { readSettings, writeSettings, stripClaudeNotifierHooks } from "../settings/claude";
+import { teardownCodexHooks } from "./codex";
 
 const HOOK_RUNNER_PREFIX = IS_WIN ? "powershell" : "node";
 
@@ -148,6 +149,8 @@ function syncFile(src: string, dest: string): void {
  * uninstall.ts when the extension is uninstalled.
  */
 export function teardownHooks(): void {
+  teardownCodexHooks();
+
   const legacyNames = [
     "claude-notifier-on-stop",
     "claude-notifier-on-permission",

--- a/src/hooks/registry.ts
+++ b/src/hooks/registry.ts
@@ -6,6 +6,11 @@ export interface HookDef {
   baseName: string;
   /** Claude Code hook type key in settings.json. */
   type: string;
+  /**
+   * Codex event name for hooks.json. Omitted when Codex has no equivalent
+   * event, which excludes the hook from the Codex registration entirely.
+   */
+  codexType?: string;
   /** Optional matcher for PreToolUse hooks. */
   matcher?: string;
   /** Key for VS Code config (claudeNotifier.<eventKey>.level/.sound). */
@@ -18,12 +23,14 @@ export const HOOKS: HookDef[] = [
   {
     baseName: "claude-notifier-on-stop",
     type: "Stop",
+    codexType: "Stop",
     eventKey: "taskCompleted",
     defaultSound: "Hero",
   },
   {
     baseName: "claude-notifier-on-permission",
     type: "PermissionRequest",
+    codexType: "PermissionRequest",
     eventKey: "needsPermission",
     defaultSound: "Glass",
   },
@@ -42,6 +49,7 @@ export const HOOKS: HookDef[] = [
     // (syncConfig, etc.) don't choke on undefined values.
     baseName: "claude-notifier-on-prompt",
     type: "UserPromptSubmit",
+    codexType: "UserPromptSubmit",
     eventKey: "userPromptSubmit",
     defaultSound: "",
   },
@@ -51,6 +59,7 @@ export const HOOKS: HookDef[] = [
     // detail rather than something the user is waiting on.
     baseName: "claude-notifier-on-subagent-stop",
     type: "SubagentStop",
+    codexType: "SubagentStop",
     eventKey: "subagentCompleted",
     defaultSound: "Pop",
   },

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -17,6 +17,13 @@ export const TASK_START_DIR = path.join(HOOKS_DIR, "claude-notifier-task-start")
 export const ACTIVE_DIR = path.join(HOOKS_DIR, "claude-notifier-active.d");
 export const OWN_PID_FILE = path.join(ACTIVE_DIR, String(process.pid));
 
+// Codex keeps its own agent home, overridable via CODEX_HOME. Only the hook
+// registry lives there; the notifier's own state (signal file, config, mute
+// flag, active markers) stays in HOOKS_DIR for every agent, so there is one
+// signal file and one watcher regardless of how many agents are installed.
+export const CODEX_DIR = process.env.CODEX_HOME || path.join(HOME, ".codex");
+export const CODEX_HOOKS_FILE = path.join(CODEX_DIR, "hooks.json");
+
 export const IS_WIN = process.platform === "win32";
 export const IS_MAC = process.platform === "darwin";
 export const IS_LINUX = process.platform === "linux";

--- a/test/unit/hooks.codex.test.ts
+++ b/test/unit/hooks.codex.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from "vitest";
+import { buildCodexHooksFile, codexHooks, stripCodexNotifierHooks } from "../../src/hooks/codex";
+
+function ourEntry(baseName: string) {
+  return {
+    hooks: [{ type: "command", command: `node ~/.claude/hooks/${baseName}.js --agent codex` }],
+  };
+}
+
+function thirdPartyEntry() {
+  return { hooks: [{ type: "command", command: "node ~/.codex/hooks/my-other-tool.js" }] };
+}
+
+describe("codexHooks", () => {
+  it("covers every event Codex supports and excludes the ones it doesn't", () => {
+    const events = codexHooks().map((h) => h.codexType);
+    expect(events).toEqual(["Stop", "PermissionRequest", "UserPromptSubmit", "SubagentStop"]);
+  });
+
+  it("omits asksQuestion, which has no Codex equivalent", () => {
+    expect(codexHooks().some((h) => h.eventKey === "asksQuestion")).toBe(false);
+  });
+});
+
+describe("stripCodexNotifierHooks", () => {
+  it("removes our entries and drops the emptied event keys", () => {
+    const file: any = {
+      hooks: {
+        Stop: [ourEntry("claude-notifier-on-stop")],
+        SubagentStop: [ourEntry("claude-notifier-on-subagent-stop")],
+      },
+    };
+    stripCodexNotifierHooks(file);
+    expect(file.hooks).toEqual({});
+  });
+
+  it("preserves third-party entries on the same event", () => {
+    const file: any = {
+      hooks: { Stop: [ourEntry("claude-notifier-on-stop"), thirdPartyEntry()] },
+    };
+    stripCodexNotifierHooks(file);
+    expect(file.hooks.Stop).toEqual([thirdPartyEntry()]);
+  });
+
+  it("leaves a file with no hooks object alone", () => {
+    const file: any = { somethingElse: 1 };
+    stripCodexNotifierHooks(file);
+    expect(file).toEqual({ somethingElse: 1 });
+  });
+});
+
+describe("buildCodexHooksFile", () => {
+  it("registers one entry per supported event", () => {
+    const file = buildCodexHooksFile({});
+    expect(Object.keys(file.hooks!).sort()).toEqual([
+      "PermissionRequest",
+      "Stop",
+      "SubagentStop",
+      "UserPromptSubmit",
+    ]);
+    for (const groups of Object.values(file.hooks!)) {
+      expect(groups).toHaveLength(1);
+      expect(groups[0].hooks![0].command).toContain("--agent codex");
+    }
+  });
+
+  it("is idempotent — rebuilding from its own output does not duplicate entries", () => {
+    const once = buildCodexHooksFile({});
+    const twice = buildCodexHooksFile(once);
+    expect(twice).toEqual(once);
+  });
+
+  it("preserves unrelated top-level keys and third-party hooks", () => {
+    const existing: any = {
+      someOtherSetting: true,
+      hooks: { Stop: [thirdPartyEntry()], PostToolUse: [thirdPartyEntry()] },
+    };
+    const file = buildCodexHooksFile(existing);
+
+    expect(file.someOtherSetting).toBe(true);
+    expect(file.hooks!.PostToolUse).toEqual([thirdPartyEntry()]);
+    // Third-party Stop hook survives alongside ours.
+    expect(file.hooks!.Stop).toHaveLength(2);
+    expect(file.hooks!.Stop[1]).toEqual(thirdPartyEntry());
+  });
+
+  it("does not mutate the input", () => {
+    const existing: any = { hooks: { Stop: [thirdPartyEntry()] } };
+    const snapshot = JSON.parse(JSON.stringify(existing));
+    buildCodexHooksFile(existing);
+    expect(existing).toEqual(snapshot);
+  });
+
+  it("keeps our entry first for each event so Codex's index-based trust keys stay stable", () => {
+    const withThirdParty = buildCodexHooksFile({
+      hooks: { Stop: [thirdPartyEntry()] },
+    });
+    expect(withThirdParty.hooks!.Stop[0].hooks![0].command).toContain("claude-notifier-on-stop");
+    expect(withThirdParty.hooks!.Stop[1]).toEqual(thirdPartyEntry());
+  });
+
+  it("caps the hook timeout so a wedged hook cannot stall a Codex turn", () => {
+    const file = buildCodexHooksFile({});
+    for (const groups of Object.values(file.hooks!)) {
+      expect(groups[0].hooks![0].timeout).toBe(10);
+    }
+  });
+});


### PR DESCRIPTION
Closes #83.

Codex sessions now drive the same notification pipeline as Claude Code — same sounds, per-event levels, mute, auto-mute, threshold, dedup, and remote audio. Codex's hook system is close enough to Claude Code's (identical payload field names) that the existing hook scripts serve both agents; they take an `--agent` argument that only decides how notifications are worded.

The extension registers `Stop`, `PermissionRequest`, `UserPromptSubmit`, and `SubagentStop` in `~/.codex/hooks.json` (honouring `CODEX_HOME`), merging alongside any hooks another tool registered. Registration is skipped entirely when Codex isn't installed, so no `~/.codex` directory is created for users who don't have it. Notifier state stays in `~/.claude/hooks/` for every agent, so there's still one signal file and one watcher.

## The trust gate

Testing the packaged .vsix surfaced the thing worth flagging for review: **installing the extension is not sufficient.** Codex will not run a newly registered hook until it's trusted, and the failure is completely silent — the hooks parse cleanly, `hooks/list` reports no warnings or errors, and Codex just never invokes them. `hooks.json` being present is not evidence that it runs.

Trust can only be granted in the Codex **TUI**: `codex` opens a "Hooks need review" screen at startup offering *Trust all and continue*. It has to be the terminal — the app-server protocol the Codex VS Code extension speaks exposes only `hooks/list`, with no method for granting trust. The trust key carries no project component, so approving once covers every project and VS Code afterwards.

Two follow-on details, both now documented:

- The bundled Codex CLI **isn't on `PATH`** when Codex arrived as the ChatGPT VS Code extension, so the one-time approval is unreachable without an export — `codex` just returns `command not found`. Hit this directly while testing.
- Trusted hooks run *outside* Codex's sandbox (its own review screen says so), which is what lets them play sounds. A sandboxed `afplay` fails with `AudioQueueStart failed (-66680)`; hooks aren't subject to that.

The extension deliberately does not write the trust hash itself. It could — trust is just a hash in `config.toml` — but that would defeat a control Codex added on purpose, and would break the moment OpenAI hardens it. Because trust pins to a hash of the *registration entry* rather than the script contents, approving once survives extension upgrades that rewrite the scripts; the registered command line is kept byte-stable to preserve that, and our entry is registered first for each event so a third-party hook appearing later can't shift the index its trust key derives from.

## Gaps

Codex has no `AskUserQuestion` analog, so `asksQuestion` stays Claude-Code-only. The PowerShell hook scripts don't read `--agent`, so Windows notifications still say "Claude".

## Testing

`npm run compile` clean; 292 tests across 45 files pass. Verified end to end against codex-cli 0.148.0-alpha.15: hooks registered, `hooks/list` confirmed all four `untrusted` before approval and `trusted` after, and notifications fire from Codex turns.